### PR TITLE
Process one event at a time to limit failure mode

### DIFF
--- a/Model/ResourceModel/Event.php
+++ b/Model/ResourceModel/Event.php
@@ -19,7 +19,7 @@ class Event extends AbstractDb
 
     const TABLE_NAME = 'solvedata_event';
 
-    const BATCH_SIZE = 1000;
+    const BATCH_SIZE = 100;
 
     /**
      * @var Config

--- a/Model/ResourceModel/Event.php
+++ b/Model/ResourceModel/Event.php
@@ -158,7 +158,7 @@ class Event extends AbstractDb
      *
      * @throws LocalizedException
      */
-    public function updateEvents(array $events, array $requestResults, bool $isException = false): int
+    public function updateEvents(array $events, array $requestResults): int
     {
         foreach ($events as &$event) {
             $event['attempt'] = $event['attempt'] + 1;

--- a/Model/ResourceModel/Event.php
+++ b/Model/ResourceModel/Event.php
@@ -164,13 +164,19 @@ class Event extends AbstractDb
             $event['attempt'] = $event['attempt'] + 1;
             $event['finished_at'] = new \Zend_Db_Expr('NOW()');
             if (empty($requestResults[$event[self::ENTITY_ID]])) {
-                $event['status'] = $isException ? EventModel::STATUS_EXCEPTION : EventModel::STATUS_FAILED;
+                $event['status'] = EventModel::STATUS_FAILED;
                 continue;
             }
 
             $eventRequestResults = $requestResults[$event[self::ENTITY_ID]];
             $event['request'] = json_encode($eventRequestResults);
+
             foreach ($eventRequestResults as $requestResult) {
+                if (!empty($requestResult['exception'])) {
+                    $event['status'] = EventModel::STATUS_EXCEPTION;
+                    break;
+                }
+
                 $responseCode = $requestResult['response']['code'];
                 $event['response_code'] = $responseCode;
                 if ($responseCode == 200 || $responseCode == 201) {

--- a/Model/ResourceModel/Event.php
+++ b/Model/ResourceModel/Event.php
@@ -158,13 +158,13 @@ class Event extends AbstractDb
      *
      * @throws LocalizedException
      */
-    public function updateEvents(array $events, array $requestResults): int
+    public function updateEvents(array $events, array $requestResults, bool $isException = false): int
     {
         foreach ($events as &$event) {
             $event['attempt'] = $event['attempt'] + 1;
             $event['finished_at'] = new \Zend_Db_Expr('NOW()');
             if (empty($requestResults[$event[self::ENTITY_ID]])) {
-                $event['status'] = EventModel::STATUS_FAILED;
+                $event['status'] = $isException ? EventModel::STATUS_EXCEPTION : EventModel::STATUS_FAILED;
                 continue;
             }
 


### PR DESCRIPTION
This moves to sending a batch of events one at a time, along with providing more information in the event of an exception.

Note: This change will significantly slow down queue processing if there are many exception-causing events, as the batch processing will not proceed past an event that throws an exception.

**Testing**:
- [x] Test the change works
- [x] Test that exceptions are correctly stringified and correctly stores the status code.
