### PR TITLE
Migrate sid usages to profile ID in GraphQL usage

### DIFF
--- a/Helper/Profile.php
+++ b/Helper/Profile.php
@@ -77,7 +77,7 @@ class Profile
     }
 
     /**
-     * Get profile sid by email
+     * Get profile id by email
      *
      * @param string $email
      * @param int|null $websiteId
@@ -86,37 +86,37 @@ class Profile
      *
      * @throws \Exception
      */
-    public function getSidByEmail(string $email, int $websiteId): string
+    public function getProfileIdByEmail(string $email, int $websiteId): string
     {
-        $sid = $this->getRegistry(sprintf('%s_%s', $email, $websiteId));
-        if (!empty($sid)) {
-            return $sid;
+        $id = $this->getRegistry(sprintf('%s_%s', $email, $websiteId));
+        if (!empty($id)) {
+            return $id;
         }
         $profile = $this->profileRepository->create();
-        $sid = $profile->getSIdByEmail($email, $websiteId);
-        if (empty($sid)) {
+        $id = $profile->getProfileIdByEmail($email, $websiteId);
+        if (empty($id)) {
             throw new \Exception(sprintf(
-                'SolveData Profile sid is empty for "%s" email in "%d" website',
+                'SolveData Profile id is empty for "%s" email in "%d" website',
                 $email,
                 $websiteId
             ));
         }
 
-        return $sid;
+        return $id;
     }
 
     /**
-     * Save profile sid from Solve service
+     * Save profile id from Solve service
      *
      * @param string $email
-     * @param string $sid
+     * @param string $id
      * @param int $websiteId
      *
      * @return Profile
      *
      * @throws AlreadyExistsException
      */
-    public function saveSidByEmail(string $email, string $sid, int $websiteId): Profile
+    public function saveProfileIdByEmail(string $email, string $id, int $websiteId): Profile
     {
         if (!empty($this->getRegistry(sprintf('%s_%s', $email, $websiteId)))) {
             return $this;
@@ -127,10 +127,10 @@ class Profile
         }
 
         $profile->setEmail($email)
-            ->setSid($sid)
+            ->setSid($id)
             ->setWebsiteId($websiteId);
         $this->profileRepository->save($profile);
-        $this->setRegistry(sprintf('%s_%s', $email, $websiteId), $sid);
+        $this->setRegistry(sprintf('%s_%s', $email, $websiteId), $id);
 
         return $this;
     }

--- a/Model/Event/Transport/Adapter/GraphQL.php
+++ b/Model/Event/Transport/Adapter/GraphQL.php
@@ -386,20 +386,20 @@ class GraphQL extends CurlAbstract
     {
         try {
             $body = json_decode($body, true);
-            if (empty($body['data']['createOrUpdateProfile']['sid'])
+            if (empty($body['data']['createOrUpdateProfile']['id'])
                 || empty($body['data']['createOrUpdateProfile']['emails'])
             ) {
                 return $this;
             }
             $email = reset($body['data']['createOrUpdateProfile']['emails']);
             $this->logger->debug(sprintf(
-                'Save sid "%s" for customer %s',
-                $body['data']['createOrUpdateProfile']['sid'],
+                'Save id "%s" for customer %s',
+                $body['data']['createOrUpdateProfile']['id'],
                 $email
             ));
-            $this->profileHelper->saveSidByEmail(
+            $this->profileHelper->saveProfileIdByEmail(
                 $email,
-                $body['data']['createOrUpdateProfile']['sid'],
+                $body['data']['createOrUpdateProfile']['id'],
                 (int)$this->storeManager->getStore($event['store_id'])->getWebsiteId()
             );
         } catch (\Throwable $t) {

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/CheckoutCartSaveAfter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/CheckoutCartSaveAfter.php
@@ -9,7 +9,7 @@ class CheckoutCartSaveAfter extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation createOrUpdateCart($input: CartInput!) {
     createOrUpdateCart(input: $input) {
-        sid
+        profile_id
     }
 }
 GRAPHQL;

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/CustomerAccountEdited.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/CustomerAccountEdited.php
@@ -9,7 +9,7 @@ class CustomerAccountEdited extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation createOrUpdateProfile($input: ProfileInput!) {
     createOrUpdateProfile(input: $input) {
-        sid,
+        id,
         emails
     }
 }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/CustomerAddressSaveAfter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/CustomerAddressSaveAfter.php
@@ -9,7 +9,7 @@ class CustomerAddressSaveAfter extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation createOrUpdateProfile($input: ProfileInput!) {
     createOrUpdateProfile(input: $input) {
-        sid,
+        id,
         emails
     }
 }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/CustomerLogin.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/CustomerLogin.php
@@ -9,7 +9,7 @@ class CustomerLogin extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation createOrUpdateProfile($input: ProfileInput!) {
     createOrUpdateProfile(input: $input) {
-        sid,
+        id,
         emails
     }
 }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/CustomerLogout.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/CustomerLogout.php
@@ -9,7 +9,7 @@ class CustomerLogout extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation createOrUpdateProfile($input: ProfileInput!) {
     createOrUpdateProfile(input: $input) {
-        sid,
+        id,
         emails
     }
 }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/CustomerRegisterSuccess.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/CustomerRegisterSuccess.php
@@ -9,7 +9,7 @@ class CustomerRegisterSuccess extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation createOrUpdateProfile($input: ProfileInput!) {
     createOrUpdateProfile(input: $input) {
-        sid,
+        id,
         emails
     }
 }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/NewsletterSubscriberSaveCommitAfter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/NewsletterSubscriberSaveCommitAfter.php
@@ -9,7 +9,7 @@ class NewsletterSubscriberSaveCommitAfter extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation createOrUpdateProfile($input: ProfileInput!) {
     createOrUpdateProfile(input: $input) {
-        sid
+        id
     }
 }
 GRAPHQL;

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/OrderCancelAfter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/OrderCancelAfter.php
@@ -12,7 +12,7 @@ class OrderCancelAfter extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation create_or_update_order($input: CreateOrderInput!) {
     create_or_update_order(input: $input) {
-        sid
+        profile_id
     }
 }
 GRAPHQL;

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
@@ -12,7 +12,7 @@ class ConvertCart extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation convertCart($id: String!, $orderId: String, $provider: String!) {
     convertCart(id: $id, orderId: $orderId, provider: $provider) {
-        sid
+        profile_id
     }
 }
 GRAPHQL;

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateOrder.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateOrder.php
@@ -11,7 +11,7 @@ class CreateOrUpdateOrder extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation create_or_update_order($input: CreateOrderInput!) {
     create_or_update_order(input: $input) {
-        sid
+        profile_id
     }
 }
 GRAPHQL;

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/RegisterGuestCustomer.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/RegisterGuestCustomer.php
@@ -12,7 +12,7 @@ class RegisterGuestCustomer extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation createOrUpdateProfile($input: ProfileInput!) {
     createOrUpdateProfile(input: $input) {
-        sid,
+        id,
         emails
     }
 }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderShipmentSaveAfter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderShipmentSaveAfter.php
@@ -12,7 +12,7 @@ class SalesOrderShipmentSaveAfter extends MutationAbstract
     const QUERY = <<<'GRAPHQL'
 mutation create_or_update_order($input: CreateOrderInput!) {
     create_or_update_order(input: $input) {
-        sid
+        profile_id
     }
 }
 GRAPHQL;

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -138,7 +138,7 @@ class PayloadConverter
     }
 
     /**
-     * Get profile sid by email and area data
+     * Get profile id by email and area data
      *
      * @param string $email
      * @param array $area
@@ -147,7 +147,7 @@ class PayloadConverter
      *
      * @throws \Exception
      */
-    protected function getProfileSid(string $email, array $area): string
+    protected function getProfileId(string $email, array $area): string
     {
         $website = $this->getWebsiteDataByArea($area);
         if (empty($website)) {
@@ -157,7 +157,7 @@ class PayloadConverter
             throw new \Exception('Website data is incorrect in area data');
         }
 
-        return $this->profileHelper->getSidByEmail($email, (int)$website['website_id']);
+        return $this->profileHelper->getProfileIdByEmail($email, (int)$website['website_id']);
     }
 
     /**
@@ -402,9 +402,9 @@ class PayloadConverter
             }
         }
 
-        $sid = $this->getProfileSid($order['customer_email'], $area);
-        if (!empty($sid)) {
-            $data['sid'] = $sid;
+        $id = $this->getProfileId($order['customer_email'], $area);
+        if (!empty($id)) {
+            $data['profile_id'] = $id;
         }
 
         if (empty($order[OrderInterface::STATE])) {
@@ -606,7 +606,7 @@ class PayloadConverter
     {
         $data = [
             'id'         => $quote['entity_id'],
-            'sid'        => $this->getProfileSid($quote['customer_email'], $area),
+            'profile_id'        => $this->getProfileId($quote['customer_email'], $area),
             'currency'   => $quote['quote_currency_code'],
             'items'      => $this->convertItemsData($allVisibleItems),
             'attributes' => json_encode($this->prepareAttributesData($area)),

--- a/Model/Profile.php
+++ b/Model/Profile.php
@@ -41,15 +41,15 @@ class Profile extends AbstractModel
     }
 
     /**
-     * Get profile sid by email
+     * Get profile id by email
      *
      * @param string $email
      * @param int $websiteId
      *
      * @return string
      */
-    public function getSIdByEmail(string $email, int $websiteId): ?string
+    public function getProfileIdByEmail(string $email, int $websiteId): ?string
     {
-        return $this->getResource()->getSidByEmail($email, $websiteId);
+        return $this->getResource()->getProfileIdByEmail($email, $websiteId);
     }
 }

--- a/Model/ResourceModel/Profile.php
+++ b/Model/ResourceModel/Profile.php
@@ -57,6 +57,9 @@ class Profile extends AbstractDb
             return null;
         }
 
+        // Note that the `profile_id` is saved in the `sid` column.
+        // This is because sid was the old name for profile IDs and we
+        //  decided not to add a schema migration just to rename this column.
         return $profile['sid'];
     }
 }

--- a/Model/ResourceModel/Profile.php
+++ b/Model/ResourceModel/Profile.php
@@ -41,7 +41,7 @@ class Profile extends AbstractDb
     }
 
     /**
-     * Get profile sid by email
+     * Get profile id by email
      *
      * @param string $email
      * @param int $websiteId
@@ -50,7 +50,7 @@ class Profile extends AbstractDb
      *
      * @throws LocalizedException
      */
-    public function getSIdByEmail(string $email, int $websiteId): ?string
+    public function getProfileIdByEmail(string $email, int $websiteId): ?string
     {
         $profile = $this->getByEmail($email, $websiteId);
         if (empty($profile)) {

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Run the following command Magento project directory (not the repository root) to
         const QUERY = <<<'GRAPHQL'
     mutation createOrUpdateProfile($input: ProfileInput!) {
         createOrUpdateProfile(input: $input) {
-            sid,
+            id,
             emails
         }
     }

--- a/Setup/Patch/Schema/CreateSolvedataProfileTable.php
+++ b/Setup/Patch/Schema/CreateSolvedataProfileTable.php
@@ -55,6 +55,7 @@ class CreateSolvedataProfileTable implements SchemaPatchInterface
             ],
             'Profile Email'
         )->addColumn(
+            // `sid` is the old name for Profile ID.
             'sid',
             Table::TYPE_TEXT,
             255,


### PR DESCRIPTION
This PR is based off @natashasheviakova's PR in the previous repository.

It replaces all usages of `sid` with the respective `id` or `profile_id` (depending on the mutation). This means that the plugin will be compatible with Solve's API when/if backwards support for `sid` is dropped.

This PR refactors the code to reference Profile IDs rather than SIDs, but it stops short of renaming the `sid` columns in the database schema. Even though we should be able to do this in a Magento migration (which should automatically be applied when the extension is upgraded via the `magento setup:upgrade` command) we have decided that it's better not to require additional migrations unless completely necessary to reduce the possibility for things to go wrong when external parties are maintaining this extension.

**Testing:**
- Create a new Magento user and ensure the user has a correct email -> profile ID mapping in the `solvedata_profile` table
- For both a old & new user perform the following actions and ensure any assoicated events have the correct profile ID included in their payloads
  - Login
  - Log out
  - Add to cart
  - Place an order
- Perform a guest checkout and verify that a profile is correctly created for them