### PR TITLE
Add extra error handling to be defensive when mapping event payloads

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/RegisterGuestCustomer.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/RegisterGuestCustomer.php
@@ -50,17 +50,16 @@ GRAPHQL;
         $event = $this->getEvent();
         $payload = $event['payload'];
 
+        $order = $payload['order'];
+        $area = $payload['area'];
+
         $input = [
-            'email' => $payload['order']['customer_email']
+            'email' => $order['customer_email'],
+            'attributes' => json_encode($this->payloadConverter->prepareAttributesData($area))
         ];
-        if (!empty($payload['order']['addresses'])) {
-            $input['addresses'] = $this->payloadConverter->convertAddressesData($payload['order']['addresses']);
-            $address = array_shift($payload['order']['addresses']);
-            $input += [
-                'firstName' => $address['firstname'],
-                'lastName'  => $address['lastname'],
-                'fullName'  => $address['firstname'] . ' ' . $address['lastname'],
-            ];
+
+        if (!empty($order['addresses'])) {
+            $input['addresses'] = $this->payloadConverter->convertAddressesData($order['addresses']);
         }
 
         return ['input' => $input];

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -207,13 +207,29 @@ class PayloadConverter
      */
     protected function prepareAttributesData(array $area): array
     {
-        $store = $this->getStoreDataByArea($area);
-        $website = $this->getWebsiteDataByArea($area);
+        $data = [];
 
-        return [
-            'store'   => !empty($store) ? $store['name'] : null,
-            'website' => !empty($website) ? $website['name'] : null,
-        ];
+        try {
+            $store = $this->getStoreDataByArea($area);
+            $website = $this->getWebsiteDataByArea($area);
+    
+            if (!empty($store) && !empty($store['name'])) {
+                $storeName = $store['name'];
+                $data["store: $storeName"] = $storeName;
+            }
+    
+            if (!empty($website) && !empty($website['name'])) {
+                $websiteName = $website['name'];
+                $data["website: $websiteName"] = $websiteName;
+            }
+    
+            return $data;
+        } catch (\Throwable $t) {
+            $this->logger->debug('failed to find store and/or website from area', ["area" => json_encode($area)]);
+            $this->logger->error($t);
+            
+            return $data;
+        }
     }
 
     public function getOrderProvider(array $area): string

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -205,7 +205,7 @@ class PayloadConverter
      *
      * @return array
      */
-    protected function prepareAttributesData(array $area): array
+    public function prepareAttributesData(array $area): array
     {
         $data = [];
 

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -650,7 +650,7 @@ class PayloadConverter
 
         if (!empty($quote['customer_email'])) {
             // Defensively handle a failed profile ID lookup in case
-            //  the event can be retroactively linked to a profile.
+            //  the cart can be retroactively linked to a profile.
             $profileId = $this->getProfileSid($quote['customer_email'], $area);
             $data['sid'] = !empty($profileId) ? $profileId : null;
         }

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -81,7 +81,7 @@ class PayloadConverter
         $this->profileHelper = $profileHelper;
         $this->regionFactory = $regionFactory;
         $this->storeManager = $storeManager;
-        $this->logger = logger;
+        $this->logger = $logger;
     }
 
     /**

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -626,12 +626,18 @@ class PayloadConverter
     {
         $data = [
             'id'         => $quote['entity_id'],
-            'sid'        => $this->getProfileSid($quote['customer_email'], $area),
             'currency'   => $quote['quote_currency_code'],
             'items'      => $this->convertItemsData($allVisibleItems),
             'attributes' => json_encode($this->prepareAttributesData($area)),
             'provider'   => $this->getOrderProvider($area),
         ];
+
+        if (!empty($quote['customer_email'])) {
+            // Defensively handle a failed profile ID lookup in case
+            //  the event can be retroactively linked to a profile.
+            $profileId = $this->getProfileSid($quote['customer_email'], $area);
+            $data['sid'] = !empty($profileId) ? $profileId : null;
+        }
 
         return $data;
     }

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -155,7 +155,7 @@ class PayloadConverter
      *
      * @throws \Exception
      */
-    protected function getProfileSid(string $email, array $area): string
+    protected function getProfileSid(string $email, array $area): ?string
     {
         try {
             $website = $this->getWebsiteDataByArea($area);
@@ -170,7 +170,7 @@ class PayloadConverter
         } catch (\Throwable $t) {
             $this->logger->debug('failed to retrieve profile id for email', ["email" => $email]);
             $this->logger->error($t);
-            return "";
+            return null;
         }
     }
 


### PR DESCRIPTION
This PR:
- Adds extra error handling when mapping event payloads to reduce the chances that we fail to process an event (and hence the entire batch) if we encounter any data issues. This error handling causes the events to omit some non-essential fields if there is an unexpected error while processing.
- Adds profile attributes when a profile is created/updated via the guest checkout profile mutation.
- Changes the store & website attributes on a profile to be able to handle the situation where the same profile uses multiple Magento stores. The current behaviour is that the last store used clobbers any previous store's attribute. While this change isn't super relevant to the rest of the PR, it seemed best to include it here to avoid merge conflicts.