### PR TITLE
Support users using the same email address across multiple Magento websites

### DIFF
--- a/Model/ResourceModel/Profile.php
+++ b/Model/ResourceModel/Profile.php
@@ -30,12 +30,16 @@ class Profile extends AbstractDb
      */
     public function getByEmail(string $email, int $websiteId)
     {
+        // Disregard the website ID when searching for a profile's ID.
+        // This is because the same profile can exist across multiple stores and
+        //  storing the website ID is unnecessary.
+
         $connection = $this->getConnection();
         $select = $connection
             ->select()
             ->from($this->getMainTable())
             ->where('email = ?', $email)
-            ->where('website_id = ?', $websiteId);
+            ->limit(1, 0); // Use any arbitrary profile ID for the email address
 
         return $connection->fetchRow($select);
     }

--- a/Setup/Patch/Schema/CreateSolvedataProfileTable.php
+++ b/Setup/Patch/Schema/CreateSolvedataProfileTable.php
@@ -80,6 +80,7 @@ class CreateSolvedataProfileTable implements SchemaPatchInterface
             ['email', 'store_id'],
             ['type' => AdapterInterface::INDEX_TYPE_UNIQUE]
         )->addIndex(
+            // TODO remove this unique constraint as multiple emails can share the same profile ID.
             $connection->getIndexName(
                 ResourceModel::TABLE_NAME,
                 ['sid'],


### PR DESCRIPTION
This PR:
- Changes the profile ID lookup logic to disregard the website ID so it can find the profile ID for the given email even if it was used in another website
- Does not save the profile ID if it already exists for another website -- this change prevent's the `solvedata_profile` table's unique constraint from being violated

**Considerations:**
The `solvedata_profile` table has a compound unique constraint on `(email, store_id)`. It appears like mysql will automatically create an index for these columns based on this unique constraint. ~Unfortunately the updated profile query has been changed to no longer supply the website ID, which will likely mean that mysql cannot take advantage of this index since we only referencing a subset of its columns.~ (see comment)

The solution to avoid a performance regression would be to either
a. Migrate the profile table's schema
b. Disregard it in entirely and always look up the profile ID every time (could be cached in Magento's per-request "registry" cache)