### PR TITLE
Fix events from the default store breaking the Admin Events UI

### DIFF
--- a/Model/Adminhtml/Source/Event/Store.php
+++ b/Model/Adminhtml/Source/Event/Store.php
@@ -80,7 +80,10 @@ class Store implements OptionSourceInterface
     {
         $options = [];
 
-        foreach ($this->storeManager->getStores() as $store) {
+        $withDefaultStore = true;
+        $stores = $this->storeManager->getStores($withDefaultStore);
+
+        foreach ($stores as $store) {
             $options[] = [
                 'value' => $store->getId(),
                 'label' => sprintf(

--- a/Model/Event/DataProvider.php
+++ b/Model/Event/DataProvider.php
@@ -94,7 +94,7 @@ class DataProvider extends ModifierPoolDataProvider
         /** @var $event Event */
         foreach ($events as $event) {
             $event->setStatus(Event::STATUSES[$event->getStatus()]);
-            $event->setStoreId($storesArray[$event->getStoreId()]);
+            $event->setStoreId($storesArray[$event->getStoreId()] ?? null);
             $this->loadedData[$event->getId()] = $event->getData();
         }
 

--- a/Model/Event/DataProvider.php
+++ b/Model/Event/DataProvider.php
@@ -94,7 +94,13 @@ class DataProvider extends ModifierPoolDataProvider
         /** @var $event Event */
         foreach ($events as $event) {
             $event->setStatus(Event::STATUSES[$event->getStatus()]);
-            $event->setStoreId($storesArray[$event->getStoreId()] ?? null);
+
+            // Defensively set the StoreId field to the store's human readable label (see EventStoreSource)
+            //  if the store exists.
+            if (array_key_exists($event->getStoreId(), $storesArray)) {
+                $event->setStoreId($storesArray[$event->getStoreId()]);
+            }
+            
             $this->loadedData[$event->getId()] = $event->getData();
         }
 


### PR DESCRIPTION
By default Magento skips over the "default store" (i.e. the store with the zeroth ID, [see here](https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Model/StoreManager.php#L179)). This breaks the admin UI from displaying any details on events originating from the default store.

![Screen Shot 2020-12-03 at 4 02 36 PM](https://user-images.githubusercontent.com/6936148/100958309-fc4e2d80-3580-11eb-8ada-051fd04c3553.png)


