### PR TITLE
Add work around to prevent failed paymentexpress payments from uncancelling orders

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -489,6 +489,18 @@ class PayloadConverter
                     $data['status'] = self::ORDER_STATUS_PROCESSED;
                     break;
                 }
+
+                // Work around for the Payment express extension which dispatches a `sales_order_save_after` event
+                //  momentarily after the canceled event.
+                // If we didn't have this work around the order would be un-canceled in Solve moments after it was canceled.
+                if ($order[OrderInterface::STATE] == Order::STATE_PENDING &&
+                    $order[OrderInterface::STATUS] == "paymentexpress_failed") {
+
+                    $data['paymentStatus'] = self::PAYMENT_STATUS_CANCELED;
+                    $data['status'] = self::ORDER_STATUS_CANCELED;
+                    break;
+                }
+                
                 $data['paymentStatus'] = self::PAYMENT_STATUS_PENDING;
                 $data['status'] = self::ORDER_STATUS_PROCESSED;
                 break;

--- a/Model/ResourceModel/Event.php
+++ b/Model/ResourceModel/Event.php
@@ -79,6 +79,8 @@ class Event extends AbstractDb
             ->order('status ' . Select::SQL_DESC)
             ->order('scheduled_at ' . Select::SQL_ASC)
             ->order('created_at ' . Select::SQL_ASC)
+            // Use the auto-incrementing ID as a tiebreaker since the datetime only use second-level precision
+            ->order('id ' . Select::SQL_ASC)
             ->limit(self::BATCH_SIZE);
 
         return $connection->fetchAll($select);


### PR DESCRIPTION
This fix is to explicitly map orders with status `paymentexpress_failed` through as canceled orders in Solve.

This is because the paymentexpress extension appears to dispatch a `sales_orders_save_after` event that (incorrectly) shows the order as pending. I say incorrectly because if we re-import the order, the event's payload has the order in state canceled instead of  shows up with state `canceled` despite  This is odd because the order appears to be canceled when fetched directly from the database (shown by manually importing the order to Solve Data) despite when there is are no additional `sales_orders_save_after` events which have occurred since.

With this fix, there is now no difference in the parameters `create_or_update_order` mutation between the `order_cancel_after` and the `sales_orders_save_after` events.