### PR TITLE
Fix item attribute merging with numeric attribute keys

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -606,7 +606,7 @@ class PayloadConverter
             }
 
             if ($item['product_type'] == Configurable::TYPE_CODE) {
-                $itemAttributes = array_merge($itemAttributes, $this->prepareConfigurableProductAttributesData($item));
+                $itemAttributes = $itemAttributes + $this->prepareConfigurableProductAttributesData($item);
             }
 
             if (!empty($itemAttributes)) {


### PR DESCRIPTION
PHP's `array_merge` function reindex array's indices which is a problem when the array is actually an associative array containing numeric attribute IDs rather than being a sparse array.

This can cause orders's `create_or_update` mutation requests to be invalid when the order contains products with numeric attributes.