### PR TITLE
Add order adjustment for gift cards

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -248,7 +248,7 @@ class PayloadConverter
             try {
                 $giftCards = json_decode($order['gift_cards'], true);
                 $giftCards = array_map(function ($giftCart) {
-                    // Pick the subset of fields we are intrested in so
+                    // Pick the subset of fields we are interested in so
                     //  we don't inadvertently map across the gift card's
                     //  code in case it has remaining balance.
                     return [

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -232,6 +232,42 @@ class PayloadConverter
         }
     }
 
+    /**
+     * Prepare and return attributes data for orders
+     *
+     * @param array $order
+     * @param array $area
+     *
+     * @return array
+     */
+    private function orderAttributes(array $order, array $area): array
+    {
+        $attributes = $this->prepareAttributesData($area);
+
+        if (!empty($order['gift_cards'])) {
+            try {
+                $giftCards = json_decode($order['gift_cards'], true);
+                $giftCards = array_map(function ($giftCart) {
+                    // Pick the subset of fields we are intrested in so
+                    //  we don't inadvertently map across the gift card's
+                    //  code in case it has remaining balance.
+                    return [
+                        'id' => $giftCart['i'] ?? null,
+                        'amount' => $giftCart['a'] ?? null,
+                        'authorized' => $giftCart['authorized'] ?? null,
+                        'balance' => $giftCart['ba'] ?? null,
+                    ];
+                }, $giftCards);
+                $attributes['gift_cards'] = json_encode($giftCards);
+            } catch (\Throwable $t) {
+                $this->logger->debug('failed to map gift card(s) in order attributes');
+                $this->logger->error($t);
+            }
+        }
+
+        return $attributes;
+    }
+
     public function getOrderProvider(array $area): string
     {
         $website = $this->getWebsiteDataByArea($area);
@@ -405,21 +441,8 @@ class PayloadConverter
             'items'           => $this->convertItemsData($allVisibleItems),
             'storeIdentifier' => (string)$order[OrderInterface::STORE_ID],
             'channel'         => self::CHANNEL_WEB,
-            'adjustments'     => [
-                [
-                    'amount'      => sprintf('%.4F', $order[OrderInterface::TAX_AMOUNT]),
-                    'description' => 'Tax amount',
-                ],
-                [
-                    'amount'      => sprintf('%.4F', $order[OrderInterface::DISCOUNT_AMOUNT]),
-                    'description' => 'Discount amount',
-                ],
-                [
-                    'amount'      => sprintf('%.4F', $order[OrderInterface::SHIPPING_AMOUNT]),
-                    'description' => 'Shipping amount',
-                ],
-            ],
-            'attributes'      => json_encode($this->prepareAttributesData($area)),
+            'adjustments'     => $this->prepareOrderAdjustments($order),
+            'attributes'      => json_encode($this->orderAttributes($order, $area)),
             'provider'        => $this->getOrderProvider($area),
         ];
         if (!empty($order['created_at'])) {
@@ -507,6 +530,42 @@ class PayloadConverter
         }
 
         return $data;
+    }
+
+    /**
+     * Return Solve's order adjustments for a Magento order
+     *
+     * @param array $order
+     *
+     * @return array
+     */
+    private function prepareOrderAdjustments(array $order): array
+    {
+        $adjustments = [];
+
+        if (!empty($order['gift_cards_amount'])) {
+            $adjustments[] = [
+                'amount'      => sprintf('-%.4F', $order['gift_cards_amount']),
+                'description' => 'Gift card',
+            ];
+        }
+        
+        $adjustments = array_merge($adjustments, [
+            [
+                'amount'      => sprintf('%.4F', $order[OrderInterface::TAX_AMOUNT]),
+                'description' => 'Tax amount',
+            ],
+            [
+                'amount'      => sprintf('%.4F', $order[OrderInterface::DISCOUNT_AMOUNT]),
+                'description' => 'Discount amount',
+            ],
+            [
+                'amount'      => sprintf('%.4F', $order[OrderInterface::SHIPPING_AMOUNT]),
+                'description' => 'Shipping amount',
+            ],
+        ]);
+
+        return $adjustments;
     }
 
     /**


### PR DESCRIPTION
The adjustment value comes from Magento’s `gift_cards_amount` field, however it should be noted that this information is duplicated across multiple different fields:

```json
"gift_cards": "[{\"i\":1234,\"c\":\"<<REDACTED>>\",\"a\":20,\"ba\":20,\"authorized\":20}]",
"base_gift_cards_amount": "20.0000",
"gift_cards_amount": "20.0000",
"base_gift_cards_invoiced": "20.0000",
"gift_cards_invoiced": "20.0000",
```
In the end, I chose to use the value from `gift_cards_amount` for this adjustment.

I’ve simply called the adjustment Gift Card, even though it should be possible to use more than just a single one.

However just in case it’d come in useful for any queries into how people are using gift cards I’ve mapped the JSON content from `gift_cards` into the order’s attributes (taking care to ensure we don’t inadvertently receive the gift card's code in case it has any remaining balance after the transaction).

I didn’t want to rely on the JSON content of the `gift_cards` field for the adjustments field in case the content of this field isn’t stable across Magento setups if they use different gift card implementations (i.e. extensions vs. Magento enterprise etc.).