### PR TITLE
Send through Magento's price, final price & original price fields as item attributes

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -599,19 +599,18 @@ class PayloadConverter
                 continue;
             }
 
-            $itemAttributes = [];
-
-            if (!empty($item['item_id'])) {
-                $itemAttributes['magento_item_id'] = $item['item_id'];
-            }
+            $itemAttributes = [
+                'magento_item_id' => $item['item_id'] ?? null,
+                'magento_original_price' => $item['original_price'] ?? null,
+                'magento_final_price' => $item['final_price'] ?? null,
+                'magento_price' => $item['price'] ?? null,
+            ];
 
             if ($item['product_type'] == Configurable::TYPE_CODE) {
                 $itemAttributes = $itemAttributes + $this->prepareConfigurableProductAttributesData($item);
             }
 
-            if (!empty($itemAttributes)) {
-                $data[$key]['itemAttributes'] = json_encode($itemAttributes);
-            }
+            $data[$key]['itemAttributes'] = json_encode($itemAttributes);
 
             /**
              * Fix because price is NULL in quote item


### PR DESCRIPTION
Adding these additional fields allows us to identity orders containing items on sale. This is in addition to the the information contained in the adjustments array for which tells us about discounts for the entire cart -- i.e. discount vouchers being applied at checkout.