### PR TITLE
Add config settings for the batch sizing

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -16,6 +16,8 @@ class Config
     const XML_PATH_ENABLED_EVENTS                = 'solvedata_events/general/enabled_events';
     const XML_PATH_ENABLED_ANONYMOUS_CART_EVENTS = 'solvedata_events/general/enabled_anonymous_cart_events';
     const XML_PATH_DEBUG                         = 'solvedata_events/general/debug';
+    const XML_PATH_CRON_BATCH_SIZE               = 'solvedata_events/general/cron_batch_size';
+    const XML_PATH_TRANSACTION_BATCH_SIZE        = 'solvedata_events/general/transaction_batch_size';
     const XML_PATH_SENTRY_DSN                    = 'solvedata_events/general/sentry_dsn';
     const XML_PATH_EVENT_RETENTION_PERIOD        = 'solvedata_events/general/event_retention_period';
     const XML_PATH_API_URL                       = 'solvedata_events/api/url';
@@ -134,6 +136,46 @@ class Config
             ScopeInterface::SCOPE_STORE,
             $store
         );
+    }
+
+    /**
+     * Get cron batch size
+     *
+     * @param integer|null $store
+     *
+     * @return int
+     */
+    public function getCronBatchSize($store = null): int
+    {
+        try {
+            return (int)$this->scopeConfig->getValue(
+                self::XML_PATH_CRON_BATCH_SIZE,
+                ScopeInterface::SCOPE_STORE,
+                $store
+            );
+        } catch (\Throwable $t) {
+            return 100;
+        }
+    }
+
+    /**
+     * Get transaction batch size
+     *
+     * @param integer|null $store
+     *
+     * @return int
+     */
+    public function getTransactionBatchSize($store = null): int
+    {
+        try {
+            return (int)$this->scopeConfig->getValue(
+                self::XML_PATH_TRANSACTION_BATCH_SIZE,
+                ScopeInterface::SCOPE_STORE,
+                $store
+            );
+        } catch (\Throwable $t) {
+            return 10;
+        }
     }
 
     public function getSentryDsn($store = null): string

--- a/Model/ResourceModel/Event.php
+++ b/Model/ResourceModel/Event.php
@@ -19,8 +19,6 @@ class Event extends AbstractDb
 
     const TABLE_NAME = 'solvedata_event';
 
-    const BATCH_SIZE = 100;
-
     /**
      * @var Config
      */
@@ -81,7 +79,7 @@ class Event extends AbstractDb
             ->order('created_at ' . Select::SQL_ASC)
             // Use the auto-incrementing ID as a tiebreaker since the datetime only use second-level precision
             ->order('id ' . Select::SQL_ASC)
-            ->limit(self::BATCH_SIZE);
+            ->limit($this->config->getCronBatchSize());
 
         return $connection->fetchAll($select);
     }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -36,6 +36,16 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+                <field id="cron_batch_size" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Cron batch size</label>
+                    <frontend_class>validate-number</frontend_class>
+                    <comment>Number of events for a cron task to process as a batch from the events table.</comment>
+                </field>
+                <field id="transaction_batch_size" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Transaction batch size</label>
+                    <frontend_class>validate-number</frontend_class>
+                    <comment>Number of events to process at once in a DB transaction.</comment>
+                </field>
                 <field id="sentry_dsn" translate="label" type="obscure" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Sentry DSN</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -7,6 +7,8 @@
                 <enabled_events>sales_order_save_after,sales_order_shipment_save_after,customer_register_success,customer_account_edited,customer_address_save_after,customer_login,customer_logout,checkout_cart_save_after,newsletter_subscriber_save_commit_after,order_cancel_after</enabled_events>
                 <enabled_anonymous_cart_events>0</enabled_anonymous_cart_events>
                 <debug>0</debug>
+                <cron_batch_size>100</cron_batch_size>
+                <transaction_batch_size>10</transaction_batch_size>
                 <sentry_dsn backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <event_retention_period>30 days</event_retention_period>
             </general>


### PR DESCRIPTION
This PR makes batch sizing configurable so we can tweak the performance (if necessary) of the import cron when processing large amounts of events (i.e. during a full historic import).