### PR TITLE
Fix mistaken non-exist constant reference

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -516,7 +516,7 @@ class PayloadConverter
                 // Work around for the Payment express extension which dispatches a `sales_order_save_after` event
                 //  momentarily after the canceled event.
                 // If we didn't have this work around the order would be un-canceled in Solve moments after it was canceled.
-                if ($order[OrderInterface::STATE] == Order::STATE_PENDING &&
+                if ($order[OrderInterface::STATE] == Order::STATE_PENDING_PAYMENT &&
                     $order[OrderInterface::STATUS] == "paymentexpress_failed") {
 
                     $data['paymentStatus'] = self::PAYMENT_STATUS_CANCELED;


### PR DESCRIPTION
This PR fixes a bug introduced in #13. `STATE_PENDING` is a non-existent constant on the `Order` class and this causes nearly all order events to fail to be processed.

I'm surprised that this code was so obviously broken. I either didn't test PR #13 at all or refactored it at the last minute. While a bug this obvious would definitely show up in smoke tests prior to cutting release, I'm still not happy it slipped through in the first place.