### PR TITLE
Fix error handling for event batches

### DIFF
--- a/Model/Event.php
+++ b/Model/Event.php
@@ -291,7 +291,8 @@ class Event extends AbstractModel
             } catch (\Throwable $t) {
                 $resource->rollBack();
 
-                $requestResults = [$eventId => [['exception' => "$t"]]];
+                $errorResult = [['exception' => "$t"]];
+                $requestResults = array_fill_keys($eventIds, $errorResult);
                 $this->updateEvents($events, $requestResults);
 
                 $this->logger->debug('Error processing event', ['event_entity_ids' => $eventIds, 'cron_id' => $cronId]);

--- a/Model/Event/Transport/Adapter/GraphQL.php
+++ b/Model/Event/Transport/Adapter/GraphQL.php
@@ -150,7 +150,8 @@ class GraphQL extends CurlAbstract
                 $this->afterRequest($event, $requestResult['response']['body']);
             }
         } catch (\Throwable $t) {
-            $this->logger->critical($t);
+            $this->logger->error($t);
+            $result[] = ['exception' => "$t"];
         }
         $this->logger->debug(sprintf(
             'Request result: %s',


### PR DESCRIPTION
This PR contains a bug fix and an improvement to error handling for events.

The fix is for a bug that was introduced in #17 where the error handling code path would always fail due to an undefined variable.

The improvement is to make sure we capture any exceptions that occur from side the GraphQL mapping logic and add them into the event entity's informational `request` JSON blob. 