### PR TITLE
Reference existing Apache 2 license in Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "solvedata/plugins-magento2",
   "description": "Magento 2 Solve Data extension",
+  "license": "Apache-2.0",
   "type": "magento2-module",
   "version": "1.0.61",
   "require": {


### PR DESCRIPTION
We have an existing LICENSE file in the repo however Composer requires the license to be referenced explicitly in the `composer.json` file.

This is to prevent the following warning in packagist
<img width="882" alt="Screen Shot 2020-12-10 at 4 19 56 PM" src="https://user-images.githubusercontent.com/6936148/101717129-96732000-3b03-11eb-982c-68ea0340545d.png">
https://packagist.org/packages/solvedata/plugins-magento2