### PR TITLE
Remove the option to send GraphQL requests in parallel

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -23,7 +23,6 @@ class Config
     const XML_PATH_API_URL                       = 'solvedata_events/api/url';
     const XML_PATH_API_KEY                       = 'solvedata_events/api/key';
     const XML_PATH_PASSWORD                      = 'solvedata_events/api/password';
-    const XML_PATH_MASS_SEND_REQUESTS            = 'solvedata_events/api/mass_send_requests';
     const XML_PATH_MAX_ATTEMPT_COUNT             = 'solvedata_events/api/max_attempt_count';
     const XML_PATH_ATTEMPT_INTERVAL              = 'solvedata_events/api/attempt_interval';
     const XML_PATH_SDK_IS_ENABLED                = 'solvedata_events/sdk/enabled';
@@ -281,22 +280,6 @@ class Config
     {
         return (int)$this->scopeConfig->getValue(
             self::XML_PATH_ATTEMPT_INTERVAL,
-            ScopeInterface::SCOPE_STORE,
-            $store
-        );
-    }
-
-    /**
-     * Get mass send requests flag
-     *
-     * @param null $store
-     *
-     * @return bool
-     */
-    public function getMassSendRequests($store = null): bool
-    {
-        return (bool)$this->scopeConfig->getValue(
-            self::XML_PATH_MASS_SEND_REQUESTS,
             ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/Model/Event/Transport/Adapter/GraphQL.php
+++ b/Model/Event/Transport/Adapter/GraphQL.php
@@ -82,28 +82,12 @@ class GraphQL extends CurlAbstract
      */
     public function sendBulk(array $events): array
     {
-        if ($this->config->getMassSendRequests()) {
-            return $this->massRequest($events);
-        }
-
         $results = [];
         foreach ($events as $event) {
-            $results[$event[ResourceModel::ENTITY_ID]] = $this->send($event);
+            $results[$event[ResourceModel::ENTITY_ID]] = $this->request($event);
         }
 
         return $results;
-    }
-
-    /**
-     * Send event
-     *
-     * @param array $event
-     *
-     * @return array
-     */
-    public function send(array $event)
-    {
-        return $this->request($event);
     }
 
     /**

--- a/Model/Event/Transport/Adapter/GraphQL.php
+++ b/Model/Event/Transport/Adapter/GraphQL.php
@@ -84,10 +84,22 @@ class GraphQL extends CurlAbstract
     {
         $results = [];
         foreach ($events as $event) {
-            $results[$event[ResourceModel::ENTITY_ID]] = $this->request($event);
+            $results[$event[ResourceModel::ENTITY_ID]] = $this->send($event);
         }
 
         return $results;
+    }
+
+    /**
+     * Send event
+     *
+     * @param array $event
+     *
+     * @return array
+     */
+    public function send(array $event)
+    {
+        return $this->request($event);
     }
 
     /**

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -67,10 +67,6 @@
                     <label>Password</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
-                <field id="mass_send_requests" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Mass Sending Requests</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                </field>
                 <field id="max_attempt_count" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Max Attempt Count</label>
                     <frontend_class>validate-number</frontend_class>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -15,7 +15,6 @@
             <api>
                 <key backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <password backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
-                <mass_send_requests>1</mass_send_requests>
                 <max_attempt_count>3</max_attempt_count>
                 <attempt_interval>1</attempt_interval>
             </api>


### PR DESCRIPTION
This feature introduced race conditions between GraphQL requests and therefore we recommend leaving it disabled.

This PR removes it entirely to ensure it's not enabled by accident.