### PR TITLE
Add support for Solve's payment & return resources

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdatePayment.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdatePayment.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter;
+
+use Magento\Sales\Api\Data\OrderPaymentInterface;
+use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbstract;
+
+class CreateOrUpdatePayment extends MutationAbstract
+{
+    const QUERY = <<<'GRAPHQL'
+mutation create_or_update_payment($input: PaymentInput!) {
+    create_or_update_payment(input: $input) {
+        id
+    }
+}
+GRAPHQL;
+
+    /**
+     * Mutation is allowed
+     *
+     * @return bool
+     */
+    public function isAllowed(): bool
+    {
+        $payload = $this->getEvent()['payload'];
+        $payment = $this->payloadConverter->getOrderPaymentData($payload['order']);
+
+        if (is_null($payment) || empty($payment[OrderPaymentInterface::AMOUNT_PAID])) {
+            return false;
+        }
+
+        $amount_paid = $payment[OrderPaymentInterface::AMOUNT_PAID];
+        if (floatval($amount_paid) === 0.0) {
+            return false;
+        }
+
+        return parent::isAllowed();
+    }
+
+    /**
+     * Get variables for GraphQL request
+     *
+     * @return array
+     *
+     * @throws \Exception
+     */
+    public function getVariables(): array
+    {
+        $payload = $this->getEvent()['payload'];
+
+        return [
+            'input' => $this->payloadConverter->convertPaymentData(
+                $payload['order'],
+                $payload['area']
+            ),
+        ];
+    }
+}

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateReturn.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateReturn.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter;
+
+use Magento\Sales\Api\Data\OrderPaymentInterface;
+use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbstract;
+
+class CreateOrUpdateReturn extends MutationAbstract
+{
+    const QUERY = <<<'GRAPHQL'
+mutation create_or_update_return($input: ReturnInput!) {
+    create_or_update_return(input: $input) {
+        id
+    }
+}
+GRAPHQL;
+
+    /**
+     * Mutation is allowed
+     *
+     * @return bool
+     */
+    public function isAllowed(): bool
+    {
+        $payload = $this->getEvent()['payload'];
+        $payment = $this->payloadConverter->getOrderPaymentData($payload['order']);
+
+        if (is_null($payment) || empty($payment[OrderPaymentInterface::AMOUNT_REFUNDED])) {
+            return false;
+        }
+
+        $amount_refunded = $payment[OrderPaymentInterface::AMOUNT_REFUNDED];
+        if (floatval($amount_refunded) === 0.0) {
+            return false;
+        }
+
+        return parent::isAllowed();
+    }
+
+    /**
+     * Get variables for GraphQL request
+     *
+     * @return array
+     *
+     * @throws \Exception
+     */
+    public function getVariables(): array
+    {
+        $payload = $this->getEvent()['payload'];
+
+        return [
+            'input' => $this->payloadConverter->convertReturnData(
+                $payload['order'],
+                $payload['area']
+            ),
+        ];
+    }
+}

--- a/etc/solvedata_events.xml
+++ b/etc/solvedata_events.xml
@@ -25,6 +25,8 @@
         <event name="sales_order_save_after">
             <mutation order="10" class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\RegisterGuestCustomer"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdateOrder"/>
+            <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdatePayment"/>
+            <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdateReturn"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\ConvertCart"/>
         </event>
         <event name="sales_order_shipment_save_after">


### PR DESCRIPTION
This PR adds support for creating payment & return resources in Solve's GraphQL API based off an order's payment details.

Is this a little crude as these payments & returns aren't actually created for individual "payments" (or transactions as Magento calls them) but rather as a single logic payment (and a return if some money is refunded) that encapsulates the total amount paid/refunded. I went down this route because I couldn't see any events that were fired when a Magento transaction is created.

I believe this is a fair trade off to make, the only down side is that we lose the granularity that Magento has in their transaction resource. But then again our payment API isn't as in-depth as Magento's anyway.

I've also removed all places where we manually set order's `paymentStatus` as these are no longer necessary now we are creating payments & returns.