### PR TITLE
Add an action to resend events

### DIFF
--- a/Controller/Adminhtml/Event/ResendEvent.php
+++ b/Controller/Adminhtml/Event/ResendEvent.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolveData\Events\Controller\Adminhtml\Event;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Ui\Component\MassAction\Filter;
+use SolveData\Events\Model\Logger;
+use SolveData\Events\Model\Event;
+use SolveData\Events\Model\ResourceModel\Event\Collection;
+use SolveData\Events\Model\ResourceModel\Event as EventModel;
+
+class ResendEvent extends Action
+{
+    protected $collection;
+    protected $eventModel;
+
+    /**
+     * @param Context $context
+     */
+    public function __construct(
+        Context $context,
+        Collection $collection,
+        EventModel $eventModel
+    ) {
+        parent::__construct($context);
+
+        $this->collection = $collection;
+        $this->eventModel = $eventModel;
+    }
+
+    public function execute()
+    {
+        $params = $this->getRequest()->getParams();
+
+        $selectedIds = [];
+        if (array_key_exists('selected', $params)) {
+            $selectedIds = $params['selected'];
+        }
+
+        if (array_key_exists('excluded', $params)) {
+            if ($params['excluded'] === 'false') {
+                $this->messageManager->addErrorMessage('Resending all events is currently not supported');
+
+                return $this->createRedirection();
+            } else {
+                $selectedIds = array_diff($selectedIds, $params['excluded']);
+            }
+        }
+
+        $events = $this->collection->addFieldToFilter('id', ['in' => $selectedIds]);
+
+        $newEvents = [];
+        foreach ($events as $event) {
+            $newEvents[] = [
+                'name'                  => $event['name'],
+                'status'                => Event::STATUS_NEW,
+                'payload'               => $event['payload'],
+                'affected_entity_id'    => $event['affected_entity_id'],
+                'affected_increment_id' => $event['affected_increment_id'] ?? null,
+                'store_id'              => $event['store_id'],
+            ];
+        }
+
+        $createdEventsCount = 0;
+        if (!empty($newEvents)) {
+            $createdEventsCount = $this->eventModel->createEvents($newEvents);
+        }
+
+        $this->messageManager->addSuccessMessage(
+            sprintf('You have added to queue %d event(s) to resend to Solve Data.', $createdEventsCount)
+        );
+
+        return $this->createRedirection();
+    }
+
+    private function createRedirection()
+    {
+        $resultRedirect = $this->resultRedirectFactory->create();
+        $resultRedirect->setPath('solvedata_events/event/index');
+        return $resultRedirect;
+    }
+}

--- a/view/adminhtml/ui_component/solvedata_events_event_listing.xml
+++ b/view/adminhtml/ui_component/solvedata_events_event_listing.xml
@@ -8,6 +8,15 @@
         <item name="spinner" xsi:type="string">spinner_columns</item>
     </argument>
     <listingToolbar name="listing_top">
+        <massaction name="listing_massaction" component="Magento_Ui/js/grid/tree-massactions">
+            <action name="solvedata_events_resend_event">
+                <settings>
+                    <url path="solvedata_events/event/resendEvent"/>
+                    <type>solvedata_events_resend_event</type>
+                    <label translate="true">Resend event(s)</label>
+                </settings>
+            </action>
+        </massaction>
         <argument name="data" xsi:type="array">
             <item name="config" xsi:type="array">
                 <item name="sticky" xsi:type="boolean">false</item>
@@ -36,6 +45,11 @@
         </argument>
     </dataSource>
     <columns name="spinner_columns">
+         <selectionsColumn name="ids">
+            <settings>
+                <indexField>id</indexField>
+            </settings>
+        </selectionsColumn>
         <column name="id">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
@@ -149,7 +163,7 @@
         </column>
         <actionsColumn name="actions" class="SolveData\Events\Ui\Component\Listing\Columns\Actions">
             <settings>
-                <label translate="true">Actions</label>
+                <label translate="true">Details</label>
             </settings>
         </actionsColumn>
     </columns>

--- a/view/adminhtml/ui_component/solvedata_events_event_listing.xml
+++ b/view/adminhtml/ui_component/solvedata_events_event_listing.xml
@@ -163,7 +163,7 @@
         </column>
         <actionsColumn name="actions" class="SolveData\Events\Ui\Component\Listing\Columns\Actions">
             <settings>
-                <label translate="true">Details</label>
+                <label translate="true">Actions</label>
             </settings>
         </actionsColumn>
     </columns>


### PR DESCRIPTION
This PR adds the ability to re-enqueue an event into the events table effectually resending it to Solve.

This is handy for events (i.e. logins, carts, etc) where we cannot reimport the underlying resource to trigger the event to be resent.

**Screenshots**
Resending an event:
<img width="1391" alt="Screen Shot 2020-12-14 at 12 06 37 PM" src="https://user-images.githubusercontent.com/6936148/102027295-076a4e80-3e08-11eb-9b65-fc2fd5047f1e.png">
<img width="1387" alt="Screen Shot 2020-12-14 at 12 06 48 PM" src="https://user-images.githubusercontent.com/6936148/102027306-118c4d00-3e08-11eb-953e-6edc0e085afd.png">

Attempting to resend all events (currently not supported):
<img width="182" alt="Screen Shot 2020-12-14 at 12 07 29 PM" src="https://user-images.githubusercontent.com/6936148/102027312-223cc300-3e08-11eb-9ae2-70a787f42f75.png">
<img width="1385" alt="Screen Shot 2020-12-14 at 12 07 41 PM" src="https://user-images.githubusercontent.com/6936148/102027316-249f1d00-3e08-11eb-9b04-33c1ecaf92bf.png">
