### PR TITLE
Add a maximum batch size when purging historical events

### DIFF
--- a/Model/ResourceModel/Event.php
+++ b/Model/ResourceModel/Event.php
@@ -99,17 +99,29 @@ class Event extends AbstractDb
     {
         $connection = $this->getConnection();
 
-        // Delete rows with a `created_at` time older than the retention period threshold time.
+        // Delete a batch of rows with their `created_at` time older than the retention period threshold time.
         //
         // Note that if PHP & MSQL have been configured with different timezones there is the
         //      possibility that this logic will be off up to ~1 day.
         // This isn't too concerning because the retention period is somewhat arbitrary and will be a
         //      long period like 7 days or 1 month.
-        $deletedRows = $connection
-            ->delete($this->getMainTable(), ['created_at < ?' => $purgeOlderThan])
-            ->order('id ' . Select::SQL_ASC)
+
+        $select = $connection
+            ->select()
+            ->from($this->getMainTable())
+            ->where('created_at < ?', $purgeOlderThan)
+            ->order('created_at ' . Select::SQL_ASC)
             ->limit(static::PURGE_HISTORICAL_EVENTS_BATCH_SIZE);
-        return $deletedRows;
+        
+        // Reimplement the connection's `deleteFromSelect` function.
+        // See https://github.com/magento/magento2/blob/2.3.5/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php#L3647
+        // This is because this function was assembling an invalid MySQL DELETE query.
+        $select->reset(\Magento\Framework\DB\Select::DISTINCT);
+        $select->reset(\Magento\Framework\DB\Select::COLUMNS);
+        $query = sprintf('DELETE %s', $select->assemble());
+
+        $result = $connection->query($query);
+        return $result->rowCount();
     }
 
     /**


### PR DESCRIPTION
This PR changes the purging historical events cron job to only delete up to 1000 events at a time.

This is to prevent the theoretical possibility of this cron job locking the table for an extended period of time when this version is first deployed to existing production environments with a large backlog of historic events to delete.

This change makes use of MySQL's non-standard support for delete queries following the form `DELETE ... ORDER BY LIMIT ...`. These queries wouldn't work with another DB like Postgres but it appears like Magento only supports MySQL so it should be safe to use this non-portable SQL feature. Alternatively we could rewrite this query to use delete where in subquery, but that seemed more complicated so I decided to stick with it as is.