### PR TITLE
Add admin page to import orders and customers

### DIFF
--- a/Controller/Adminhtml/Import/Import.php
+++ b/Controller/Adminhtml/Import/Import.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolveData\Events\Controller\Adminhtml\Import;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory as CustomerCollectionFactory;
+use Magento\Framework\Api\SortOrder;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory as OrderCollectionFactory;
+use SolveData\Events\Model\EventRepository;
+use SolveData\Events\Model\Logger;
+
+class Import extends Action
+{
+    const ENTITY_CUSTOMERS = 'customers';
+    const ENTITY_ORDERS    = 'orders';
+
+    const PAGE_SIZE = 1000;
+
+    private $customerCollectionFactory;
+    private $orderCollectionFactory;
+    private $eventRepository;
+    private $logger;
+
+    /**
+     * @param Context $context
+     */
+    public function __construct(
+        Context $context,
+        CustomerCollectionFactory $customerCollectionFactory,
+        OrderCollectionFactory $orderCollectionFactory,
+        EventRepository $eventRepository,
+        Logger $logger
+    ) {
+        parent::__construct($context);
+
+        $this->customerCollectionFactory = $customerCollectionFactory;
+        $this->orderCollectionFactory = $orderCollectionFactory;
+        $this->eventRepository = $eventRepository;
+        $this->logger = $logger;
+    }
+
+    public function execute()
+    {
+        $data = $this->getRequest()->getPostValue();
+
+        $entity = $data['entity'] ?? null;
+        if (empty($entity) || !in_array($entity, [static::ENTITY_CUSTOMERS, static::ENTITY_ORDERS])) {
+            throw new \Exception(sprintf('Invalid resource entity %s', $entity));
+        }
+
+        $from = null;
+        if (array_key_exists('id_from', $data)) {
+            if (!is_numeric($data['id_from'])) {
+                throw new \Exception(sprintf('Invalid id from %s', $data['id_from']));
+            }
+
+            $from = (int)$data['id_from'];
+        }
+
+        $to = null;
+        if (array_key_exists('id_to', $data)) {
+            if (!is_numeric($data['id_to'])) {
+                throw new \Exception(sprintf('Invalid id to %s', $data['id_to']));
+            }
+
+            $to = (int)$data['id_to'];
+        }
+
+        $this->logger->debug('Attempting to import entities', [
+            'entity' => $entity,
+            'from'   => $from,
+            'to'     => $to,
+        ]);
+
+        $collection = $this->getCollection($entity, $from, $to);
+        $pages = $collection->getLastPageNumber();
+
+        $page = 1;
+        $affectedRows = 0;
+        while ($page <= $pages) {
+            $collection->setCurPage($page++);
+            $collection->clear();
+            $affectedRows += $this->placeItems($entity, $collection->getItems());
+        }
+
+        $this->logger->debug('Succesfully import entities', [
+            'entity'        => $entity,
+            'from'          => $from,
+            'to'            => $to,
+            'affected_rows' => $affectedRows,
+        ]);
+
+        $this->messageManager->addSuccessMessage(sprintf(
+            'Successfully queued %d events',
+            $affectedRows
+        ));
+
+        $resultRedirect = $this->resultRedirectFactory->create();
+        $resultRedirect->setPath('solvedata_events/event/index');
+
+        return $resultRedirect;
+    }
+
+    private function getCollection(string $entity, ?int $from, ?int $to)
+    {
+        $collectionFactory = null;
+
+        if ($entity === static::ENTITY_CUSTOMERS) {
+            $collectionFactory = $this->customerCollectionFactory;
+        } else if ($entity === static::ENTITY_ORDERS) {
+            $collectionFactory = $this->orderCollectionFactory;
+        } else {
+            throw new \Exception(sprintf('Invalid resource entity %s', $entity));
+        }
+
+        /** @var AbstractDb $collection */
+        $collection = $collectionFactory->create();
+        $select = $collection->getSelect();
+        if (!is_null($from)) {
+            $select->where('entity_id >= ?', $from);
+        }
+        if (!is_null($to)) {
+            $select->where('entity_id <= ?', $to);
+        }
+        $collection->setOrder('entity_id', SortOrder::SORT_DESC);
+        $collection->setPageSize(static::PAGE_SIZE);
+
+        return $collection;
+    }
+
+    private function placeItems(string $entity, array $items): int
+    {
+        $event = $this->eventRepository->create();
+
+        if ($entity === static::ENTITY_CUSTOMERS) {
+            return $event->placeCustomers($items);
+        } else if ($entity === static::ENTITY_ORDERS) {
+            return $event->placeOrders($items);
+        } else {
+            throw new \Exception(sprintf('Invalid resource entity %s', $entity));
+        }
+    }
+}

--- a/Controller/Adminhtml/Import/Index.php
+++ b/Controller/Adminhtml/Import/Index.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolveData\Events\Controller\Adminhtml\Import;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action
+{
+    /**
+     * @var PageFactory
+     */
+    protected $resultPageFactory;
+
+    /**
+     * @param Context $context
+     * @param PageFactory $resultPageFactory
+     */
+    public function __construct(
+        Context $context,
+        PageFactory $resultPageFactory
+    ) {
+        parent::__construct($context);
+        $this->resultPageFactory = $resultPageFactory;
+    }
+
+    /**
+     * Execute index action
+     *
+     * @return Page
+     */
+    public function execute(): Page
+    {
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->getConfig()->getTitle()->prepend((__('Import')));
+
+        return $resultPage;
+    }
+}

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -18,5 +18,14 @@
              dependsOnModule="SolveData_Events"
              action="solvedata_events/event"
              resource="SolveData_Events::event"/>
+        <add id="SolveData_Events::import"
+             title="Import"
+             translate="title"
+             module="SolveData_Events"
+             parent="SolveData_Events::event"
+             sortOrder="20"
+             dependsOnModule="SolveData_Events"
+             action="solvedata_events/import"
+             resource="SolveData_Events::event"/>
     </menu>
 </config>

--- a/view/adminhtml/layout/solvedata_events_import_index.xml
+++ b/view/adminhtml/layout/solvedata_events_import_index.xml
@@ -1,0 +1,8 @@
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="Magento\Backend\Block\Template" template="SolveData_Events::import_form.phtml"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/templates/import_form.phtml
+++ b/view/adminhtml/templates/import_form.phtml
@@ -1,0 +1,28 @@
+<form class="form" action="<?= $this->getUrl('solvedata_events/import/import'); ?>" method="post">
+    <?php echo $this->getBlockHtml('formkey') ?>
+    <div class="field required">
+        <select name="entity" id="entity">
+            <option value="customers">Customers</option>
+            <option value="orders">Orders</option>
+        </select>
+    </div>
+    <div class="field required">
+        <label for="id_from" class="label"><span><?php echo __('ID From') ?></span></label>
+        <div class="control">
+            <input type="text" id="id_from" name="id_from" class="input-text validate-number validate-zero-or-greater"/>
+        </div>
+    </div>
+    <div class="field required">
+        <label for="id_to" class="label"><span><?php echo __('ID To') ?></span></label>
+        <div class="control">
+            <input type="text" id="id_to" name="id_to" class="input-text validate-number validate-zero-or-greater"/>
+        </div>
+    </div>
+    <div class="actions-toolbar">
+        <div class="primary">
+            <button type="submit" class="action submit primary" title="<?php echo __('Import') ?>">
+                <span><?php echo __('Submit') ?></span>
+            </button>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
This PR adds a simple page to allow anyone to import pre-existing customers/orders into Solve. The extension already has the functionality to import these entities into Solve but it's via Magento CLI commands and therefore requires access to the Magento server in question.

The import is kicked off via a form submission. Magento requires all forms to have a valid anti-CSRF token and this form is no exception.

**Screenshots**
<img width="892" alt="Screen Shot 2020-12-14 at 4 04 38 PM" src="https://user-images.githubusercontent.com/6936148/102035967-a00fc700-3e26-11eb-87a9-6f273636f297.png">
<img width="221" alt="Screen Shot 2020-12-14 at 4 04 48 PM" src="https://user-images.githubusercontent.com/6936148/102035980-a43be480-3e26-11eb-92d2-7899797db458.png">
<img width="1392" alt="Screen Shot 2020-12-14 at 4 04 57 PM" src="https://user-images.githubusercontent.com/6936148/102035990-a736d500-3e26-11eb-8f1b-c88b41d41ca6.png">
