### PR TITLE
Convert guest customer's carts when the anonymous carts feature is enabled

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter;
 
 use Magento\Sales\Api\Data\OrderInterface;
+use SolveData\Events\Model\Config;
 use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbstract;
+use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\PayloadConverter;
 
 class ConvertCart extends MutationAbstract
 {

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
@@ -18,6 +18,25 @@ mutation convertCart($id: String!, $orderId: String, $provider: String!) {
 GRAPHQL;
 
     /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * @param Config $config
+     * @param PayloadConverter $payloadConverter
+     * @param array $data
+     */
+    public function __construct(
+        Config $config,
+        PayloadConverter $payloadConverter,
+        array $data = []
+    ) {
+        $this->config = $config;
+        parent::__construct($payloadConverter, $data);
+    }
+
+    /**
      * Mutation is allowed
      *
      * @return bool
@@ -25,10 +44,27 @@ GRAPHQL;
     public function isAllowed(): bool
     {
         $payload = $this->getEvent()['payload'];
-        if (empty($payload['order'][OrderInterface::EXTENSION_ATTRIBUTES_KEY]['is_object_new'])
-            || !empty($payload['order'][OrderInterface::CUSTOMER_IS_GUEST])
-            || empty($payload['order'][OrderInterface::REMOTE_IP])
-        ) {
+        $order = $payload['order'];
+
+        // The `is_object_new` extension attribute is set by the plugin on all new orders.
+        // If the attribute is missing this indicates that the order pre-dates the plugin
+        //      and therefore no cart will exist in Solve.
+        $historicOrder = empty($order[OrderInterface::EXTENSION_ATTRIBUTES_KEY]['is_object_new']);
+        if ($historicOrder) {
+            return false;
+        }
+
+        // The absence of an order's `remote_ip` field is inferred to mean that the order wasn't created by
+        //      a human and therefore there no associated cart would have been created.
+        $automatedOrder = empty($order[OrderInterface::REMOTE_IP]);
+        if ($automatedOrder) {
+            return false;
+        }
+
+        // Only attempt to convert carts for guest users if the plugin has been configured to create
+        //      carts for anonymous customers.
+        $guestOrder = !empty($order[OrderInterface::CUSTOMER_IS_GUEST]);
+        if ($guestOrder && $this->config->isAnonymousCartsEnabled() === false) {
             return false;
         }
 
@@ -48,7 +84,7 @@ GRAPHQL;
 
         return [
             'id'       => $payload['order'][OrderInterface::QUOTE_ID],
-            'orderId' => $payload['order'][OrderInterface::INCREMENT_ID],
+            'orderId'  => $payload['order'][OrderInterface::INCREMENT_ID],
             'provider' => $this->payloadConverter->getOrderProvider($payload['area']),
         ];
     }


### PR DESCRIPTION
I realised that the plugin won't attempt to convert guest customer's carts even if we are have enabled tracking anonymous carts.

This PR fixes this by attempting to convert the carts when the feature flag is enabled.

Since cart conversion is the riskiest mutation, it is the last mutation to be attempted for order creation. This means that even if we introduce a bug in this mutation class the plugin should still create the order, payment & return (if any) before failing.