### PR TITLE
Fix/create or update order graphq type

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/OrderCancelAfter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/OrderCancelAfter.php
@@ -10,7 +10,7 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\PayloadConverter;
 class OrderCancelAfter extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation create_or_update_order($input: CreateOrderInput!) {
+mutation create_or_update_order($input: CreateOrUpdateOrderInput!) {
     create_or_update_order(input: $input) {
         profile_id
     }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateOrder.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateOrder.php
@@ -9,7 +9,7 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbst
 class CreateOrUpdateOrder extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation create_or_update_order($input: CreateOrderInput!) {
+mutation create_or_update_order($input: CreateOrUpdateOrderInput!) {
     create_or_update_order(input: $input) {
         profile_id
     }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderShipmentSaveAfter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderShipmentSaveAfter.php
@@ -10,7 +10,7 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\PayloadConverter;
 class SalesOrderShipmentSaveAfter extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation create_or_update_order($input: CreateOrderInput!) {
+mutation create_or_update_order($input: CreateOrUpdateOrderInput!) {
     create_or_update_order(input: $input) {
         profile_id
     }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Magento 2 Solve Data extension",
   "license": "Apache-2.0",
   "type": "magento2-module",
-  "version": "1.0.63",
+  "version": "1.0.64",
   "require": {
     "php": "~7.2",
     "magento/module-catalog": ">=103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SolveData_Events" setup_version="1.0.63">
+    <module name="SolveData_Events" setup_version="1.0.64">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Checkout"/>


### PR DESCRIPTION
This fix must be released before absinthe is upgraded to 1.6 https://github.com/solvedata/solvedata/pull/2596 . Absinthe 1.6 actually checks the input type in the graphql query, whereas 1.4 lets you type literally anything and accepts it

This is an old breaking change that i forgot to check affected anyone.