### PR TITLE
Use a default payment ID when no other suitable ID exists & additional fixes

### DIFF
--- a/Model/Event/RegisterHandler/Sales/OrderCancel.php
+++ b/Model/Event/RegisterHandler/Sales/OrderCancel.php
@@ -25,6 +25,7 @@ class OrderCancel extends EventAbstract
         $order = $observer->getEvent()->getOrder();
         try {
             if (empty($order->getState())) {
+                $this->logger->info('order state is empty for order ' . $order->getEntityId());
                 throw new \Exception('Order state is empty');
             }
         } catch (\Exception $e) {

--- a/Model/Event/RegisterHandler/Sales/OrderSave.php
+++ b/Model/Event/RegisterHandler/Sales/OrderSave.php
@@ -25,6 +25,7 @@ class OrderSave extends EventAbstract
         $order = $observer->getEvent()->getOrder();
         try {
             if (empty($order->getState())) {
+                $this->logger->info('order state is empty for order ' . $order->getEntityId());
                 throw new \Exception('Order state is empty');
             }
         } catch (\Exception $e) {

--- a/Model/Event/RegisterHandler/Sales/OrderShipmentSave.php
+++ b/Model/Event/RegisterHandler/Sales/OrderShipmentSave.php
@@ -26,6 +26,7 @@ class OrderShipmentSave extends EventAbstract
         $order = $shipment->getOrder();
         try {
             if (empty($order->getState())) {
+                $this->logger->info('order state is empty for order ' . $order->getEntityId());
                 throw new \Exception('Order state is empty');
             }
         } catch (\Exception $e) {

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -573,9 +573,18 @@ class PayloadConverter
     public function convertPaymentData(array $order, array $area): array
     {
         $payment = $this->getOrderPaymentData($order);
+
+        $orderId = $order[OrderInterface::INCREMENT_ID];
+
+        // Use the order ID suffixed with `-payment` as a default ID if no
+        //  entity ID is present in the payment data.
+        $paymentId = !empty($payment[OrderPaymentInterface::ENTITY_ID])
+            ? $payment[OrderPaymentInterface::ENTITY_ID]
+            : $orderId . "-payment";
+
         $data = [
-            'id'         => $payment[OrderPaymentInterface::ENTITY_ID],
-            'order_id'   => $order[OrderInterface::INCREMENT_ID],
+            'id'         => $paymentId,
+            'order_id'   => $orderId,
             'provider'   => $this->getOrderProvider($area),
             'amount'     => sprintf('%.4F', $payment[OrderPaymentInterface::AMOUNT_PAID]),
             'attributes' => json_encode($this->paymentAndReturnAttributes($payment, $area)),
@@ -624,10 +633,13 @@ class PayloadConverter
         $adjustments = [];
 
         if (!empty($order['gift_cards_amount'])) {
-            $adjustments[] = [
-                'amount'      => sprintf('-%.4F', $order['gift_cards_amount']),
-                'description' => 'Gift card',
-            ];
+            $giftCardsAmount = $order['gift_cards_amount'];
+            if (is_numeric($giftCardsAmount) && $giftCardsAmount > 0) {
+                $adjustments[] = [
+                    'amount'      => sprintf('-%.4F', $giftCardsAmount),
+                    'description' => 'Gift card',
+                ];
+            }
         }
         
         $adjustments = array_merge($adjustments, [

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -575,15 +575,10 @@ class PayloadConverter
         $payment = $this->getOrderPaymentData($order);
 
         $orderId = $order[OrderInterface::INCREMENT_ID];
-
-        // Use the order ID suffixed with `-payment` as a default ID if no
-        //  entity ID is present in the payment data.
-        $paymentId = !empty($payment[OrderPaymentInterface::ENTITY_ID])
-            ? $payment[OrderPaymentInterface::ENTITY_ID]
-            : $orderId . "-payment";
-
         $data = [
-            'id'         => $paymentId,
+            // Use the order ID suffixed with `-payment` as a default ID when the
+            //  payment data is missing an entity ID.
+            'id'         => $payment[OrderPaymentInterface::ENTITY_ID] ?? $orderId . "-payment",
             'order_id'   => $orderId,
             'provider'   => $this->getOrderProvider($area),
             'amount'     => sprintf('%.4F', $payment[OrderPaymentInterface::AMOUNT_PAID]),

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Magento 2 Solve Data extension",
   "license": "Apache-2.0",
   "type": "magento2-module",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "require": {
     "php": "~7.2",
     "magento/module-catalog": ">=103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SolveData_Events" setup_version="1.0.64">
+    <module name="SolveData_Events" setup_version="1.0.65">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Checkout"/>

--- a/etc/solvedata_events.xml
+++ b/etc/solvedata_events.xml
@@ -25,9 +25,9 @@
         <event name="sales_order_save_after">
             <mutation order="10" class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\RegisterGuestCustomer"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdateOrder"/>
-            <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\ConvertCart"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdatePayment"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdateReturn"/>
+            <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\ConvertCart"/>
         </event>
         <event name="sales_order_shipment_save_after">
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderShipmentSaveAfter"/>

--- a/etc/solvedata_events.xml
+++ b/etc/solvedata_events.xml
@@ -25,9 +25,9 @@
         <event name="sales_order_save_after">
             <mutation order="10" class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\RegisterGuestCustomer"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdateOrder"/>
+            <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\ConvertCart"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdatePayment"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdateReturn"/>
-            <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\ConvertCart"/>
         </event>
         <event name="sales_order_shipment_save_after">
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderShipmentSaveAfter"/>


### PR DESCRIPTION
This PR fixes a few bugs found from releasing the previous version `1.0.64`.

Namely:

- Uses a default payment ID of `${ORDER_ID}-payment` when no other suitable ID can be found on the payment data.
- Only adds a gift card adjustment discount when there is a non-zero total from the gift card.
- Logs the order ID before failing processing an order because it's got an unset state. This does not fix the error but will allow us to track down which orders are causing these errors.

This PR also changes the ordering of the convert cart mutation to be before the payment. This is just so a failed payment mutation doesn't stop us from marking the cart as successfully converted.