### PR TITLE
Handle missing payment entity IDs for returns

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -600,7 +600,7 @@ class PayloadConverter
     {
         $payment = $this->getOrderPaymentData($order);
         $data = [
-            'id'            => $payment[OrderPaymentInterface::ENTITY_ID],
+            'id'            => $payment[OrderPaymentInterface::ENTITY_ID] ?? $orderId . "-return",
             'order_id'      => $order[OrderInterface::INCREMENT_ID],
             'provider'      => $this->getOrderProvider($area),
             'return_reason' => 'Refund',


### PR DESCRIPTION
This PR applies the same fix as #35 but for returns.