### PR TITLE
Add an adjustment for discount tax compensation

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -637,6 +637,8 @@ class PayloadConverter
             }
         }
 
+        // Only include the discount amount adjustment if there is a
+        //      non-zero discount on the order.
         if (!empty($order[OrderInterface::DISCOUNT_AMOUNT])) {
             $discountAmount = $order[OrderInterface::DISCOUNT_AMOUNT];
             if (is_numeric($discountAmount) && $discountAmount != 0) {
@@ -657,6 +659,8 @@ class PayloadConverter
             'description' => 'Tax amount',
         ];
 
+        // Only include the discount tax compensation amount adjustment if there is a
+        //      non-zero compensation amount on the order.
         if (!empty($order[OrderInterface::DISCOUNT_TAX_COMPENSATION_AMOUNT])) {
             $discountCompensationAmount = $order[OrderInterface::DISCOUNT_TAX_COMPENSATION_AMOUNT];
             if (is_numeric($discountCompensationAmount) && $discountCompensationAmount != 0) {

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -636,21 +636,36 @@ class PayloadConverter
                 ];
             }
         }
+
+        if (!empty($order[OrderInterface::DISCOUNT_AMOUNT])) {
+            $discountAmount = $order[OrderInterface::DISCOUNT_AMOUNT];
+            if (is_numeric($discountAmount) && $discountAmount != 0) {
+                $adjustments[] = [
+                    'amount'      => sprintf('%.4F', $discountAmount),
+                    'description' => 'Discount amount',
+                ];
+            }
+        }
         
-        $adjustments = array_merge($adjustments, [
-            [
-                'amount'      => sprintf('%.4F', $order[OrderInterface::TAX_AMOUNT]),
-                'description' => 'Tax amount',
-            ],
-            [
-                'amount'      => sprintf('%.4F', $order[OrderInterface::DISCOUNT_AMOUNT]),
-                'description' => 'Discount amount',
-            ],
-            [
-                'amount'      => sprintf('%.4F', $order[OrderInterface::SHIPPING_AMOUNT]),
-                'description' => 'Shipping amount',
-            ],
-        ]);
+        $adjustments[] = [
+            'amount'      => sprintf('%.4F', $order[OrderInterface::SHIPPING_AMOUNT]),
+            'description' => 'Shipping amount',
+        ];
+
+        $adjustments[] = [
+            'amount'      => sprintf('%.4F', $order[OrderInterface::TAX_AMOUNT]),
+            'description' => 'Tax amount',
+        ];
+
+        if (!empty($order[OrderInterface::DISCOUNT_TAX_COMPENSATION_AMOUNT])) {
+            $discountCompensationAmount = $order[OrderInterface::DISCOUNT_TAX_COMPENSATION_AMOUNT];
+            if (is_numeric($discountCompensationAmount) && $discountCompensationAmount != 0) {
+                $adjustments[] = [
+                    'amount'      => sprintf('%.4F', $discountCompensationAmount),
+                    'description' => 'Discount tax compensation amount',
+                ];
+            }
+        }
 
         return $adjustments;
     }


### PR DESCRIPTION
Currently the Magento extension uses tax exclusive prices with an adjustment for tax while the discount adjustment factors in the discount on tax. Unfortunately this means that when a discount is applied the resulting total is less than the actual total for the order.

This PR solves this by adding a tax compensation adjustment to match sure the total price is correct.

In future we should review whether our method of handling tax is the best solution (note our Shopify integration is tax inclusive in its subtotals).

**Food for thought**
This PR changes the discount adjustment to only be included in the order's adjustment if the discount amount is non-zero. This subtlety changes the shape of data in the query engine which could break queries which expect the discount amount adjustment to always exist.

While I don't believe such queries currently exist, it's certainly an interesting consequence of changing a 3rd party integration.