### PR TITLE
Fix historic orders not converting carts

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
@@ -65,7 +65,7 @@ GRAPHQL;
 
         // Only attempt to convert carts for guest users if the plugin has been configured to create
         //      carts for anonymous customers.
-        $guestOrder = !empty($order[OrderInterface::CUSTOMER_IS_GUEST]);
+        $guestOrder = !empty($order[OrderInterface::CUSTOMER_IS_GUEST]) && boolval($order[OrderInterface::CUSTOMER_IS_GUEST]);
         if ($guestOrder && $this->config->isAnonymousCartsEnabled() === false) {
             return false;
         }


### PR DESCRIPTION
This bug is caused because the previous versions of the code only tested whether the `customer_is_guest` flag was present.

Unfortunately while this flag is only present for new orders if the user was a guest, historically imported orders have this flag as `0`. Therefore we should actually test the value of the flag.

The plugin already does not attempt to convert carts when the order was created before the Solve plugin was first installed via testing for the presence of the `is_object_new` extension attribute. However I would expect this change to cause many historic orders to have their convert cart calls fail as their cart may not actually exist because we have only recently been tracking guest carts since a couple of versions ago.