### PR TITLE
Generate stable IDs for payments/returns instead of relying on payments entity ID

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -576,9 +576,9 @@ class PayloadConverter
 
         $orderId = $order[OrderInterface::INCREMENT_ID];
         $data = [
-            // Use the order ID suffixed with `-payment` as a default ID when the
-            //  payment data is missing an entity ID.
-            'id'         => $payment[OrderPaymentInterface::ENTITY_ID] ?? $orderId . "-payment",
+            // Use the order ID suffixed with `-payment` as the payment's ID as payments's
+            //  entity ID field does not always exist.
+            'id'         => $orderId . "-payment",
             'order_id'   => $orderId,
             'provider'   => $this->getOrderProvider($area),
             'amount'     => sprintf('%.4F', $payment[OrderPaymentInterface::AMOUNT_PAID]),
@@ -600,7 +600,9 @@ class PayloadConverter
     {
         $payment = $this->getOrderPaymentData($order);
         $data = [
-            'id'            => $payment[OrderPaymentInterface::ENTITY_ID] ?? $orderId . "-return",
+            // Use the order ID suffixed with `-return` as the return's ID as payments's
+            //  entity ID field does not always exist.
+            'id'            => $orderId . "-return",
             'order_id'      => $order[OrderInterface::INCREMENT_ID],
             'provider'      => $this->getOrderProvider($area),
             'return_reason' => 'Refund',


### PR DESCRIPTION
I've since realised that a payment's entity ID is only generated and stored in the payments data when the payment (or transaction) is stored in the DB. Because different payment extensions store their transactions at different stages of an order's lifecycle we shouldn't rely on the `entity_id` at all.

This is to avoid the same order's payment being created twice under two different Solve payment IDs.