### PR TITLE
Ensure a profile exists in Solve before importing Magento orders & other importing fixes

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -12,21 +12,22 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class Config
 {
-    const XML_PATH_IS_ENABLED                    = 'solvedata_events/general/enabled';
-    const XML_PATH_ENABLED_EVENTS                = 'solvedata_events/general/enabled_events';
-    const XML_PATH_ENABLED_ANONYMOUS_CART_EVENTS = 'solvedata_events/general/enabled_anonymous_cart_events';
-    const XML_PATH_DEBUG                         = 'solvedata_events/general/debug';
-    const XML_PATH_CRON_BATCH_SIZE               = 'solvedata_events/general/cron_batch_size';
-    const XML_PATH_TRANSACTION_BATCH_SIZE        = 'solvedata_events/general/transaction_batch_size';
-    const XML_PATH_SENTRY_DSN                    = 'solvedata_events/general/sentry_dsn';
-    const XML_PATH_EVENT_RETENTION_PERIOD        = 'solvedata_events/general/event_retention_period';
-    const XML_PATH_API_URL                       = 'solvedata_events/api/url';
-    const XML_PATH_API_KEY                       = 'solvedata_events/api/key';
-    const XML_PATH_PASSWORD                      = 'solvedata_events/api/password';
-    const XML_PATH_MAX_ATTEMPT_COUNT             = 'solvedata_events/api/max_attempt_count';
-    const XML_PATH_ATTEMPT_INTERVAL              = 'solvedata_events/api/attempt_interval';
-    const XML_PATH_SDK_IS_ENABLED                = 'solvedata_events/sdk/enabled';
-    const XML_PATH_SDK_INIT_CODE                 = 'solvedata_events/sdk/init_code';
+    const XML_PATH_IS_ENABLED                       = 'solvedata_events/general/enabled';
+    const XML_PATH_ENABLED_EVENTS                   = 'solvedata_events/general/enabled_events';
+    const XML_PATH_ENABLED_ANONYMOUS_CART_EVENTS    = 'solvedata_events/general/enabled_anonymous_cart_events';
+    const XML_PATH_ENABLED_CONVERT_HISTORICAL_CARTS = 'solvedata_events/general/enabled_convert_historical_carts';
+    const XML_PATH_DEBUG                            = 'solvedata_events/general/debug';
+    const XML_PATH_CRON_BATCH_SIZE                  = 'solvedata_events/general/cron_batch_size';
+    const XML_PATH_TRANSACTION_BATCH_SIZE           = 'solvedata_events/general/transaction_batch_size';
+    const XML_PATH_SENTRY_DSN                       = 'solvedata_events/general/sentry_dsn';
+    const XML_PATH_EVENT_RETENTION_PERIOD           = 'solvedata_events/general/event_retention_period';
+    const XML_PATH_API_URL                          = 'solvedata_events/api/url';
+    const XML_PATH_API_KEY                          = 'solvedata_events/api/key';
+    const XML_PATH_PASSWORD                         = 'solvedata_events/api/password';
+    const XML_PATH_MAX_ATTEMPT_COUNT                = 'solvedata_events/api/max_attempt_count';
+    const XML_PATH_ATTEMPT_INTERVAL                 = 'solvedata_events/api/attempt_interval';
+    const XML_PATH_SDK_IS_ENABLED                   = 'solvedata_events/sdk/enabled';
+    const XML_PATH_SDK_INIT_CODE                    = 'solvedata_events/sdk/init_code';
 
     /**
      * @var ScopeConfigInterface
@@ -116,6 +117,22 @@ class Config
     {
         return (bool)$this->scopeConfig->getValue(
             self::XML_PATH_ENABLED_ANONYMOUS_CART_EVENTS,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    /**
+     * Convert carts from historical orders?
+     *
+     * @param integer|null $store
+     *
+     * @return bool
+     */
+    public function convertHistoricalCarts($store = null): bool
+    {
+        return (bool)$this->scopeConfig->getValue(
+            self::XML_PATH_ENABLED_CONVERT_HISTORICAL_CARTS,
             ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
@@ -65,7 +65,7 @@ GRAPHQL;
 
         // Only attempt to convert carts for guest users if the plugin has been configured to create
         //      carts for anonymous customers.
-        $guestOrder = !empty($order[OrderInterface::CUSTOMER_IS_GUEST]) && boolval($order[OrderInterface::CUSTOMER_IS_GUEST]);
+        $guestOrder = !empty($order[OrderInterface::CUSTOMER_IS_GUEST]);
         if ($guestOrder && $this->config->isAnonymousCartsEnabled() === false) {
             return false;
         }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
@@ -53,16 +53,16 @@ GRAPHQL;
             return false;
         }
 
-        // The `is_object_new` extension attribute is set by the plugin on all new orders.
-        // If the attribute is missing this indicates that the order pre-dates the plugin
-        //      and therefore no cart will exist in Solve.
+        // The `is_object_new` extension attribute is set by the plugin on events where the order has just been placed
+        //      and hasn't been saved into the database yet.
         $historicOrder = empty($order[OrderInterface::EXTENSION_ATTRIBUTES_KEY]['is_object_new']);
-        if ($historicOrder) {
+        if ($historicOrder && $this->config->convertHistoricalCarts() === false) {
             return false;
         }
 
         // The absence of an order's `remote_ip` field is inferred to mean that the order was created by
         //      an automated process rather than a customer and therefore no associated cart would have been created.
+        // Note (Liam): I'm unsure whether this is necessary.
         $automatedOrder = empty($order[OrderInterface::REMOTE_IP]);
         if ($automatedOrder) {
             return false;

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
@@ -48,6 +48,11 @@ GRAPHQL;
         $payload = $this->getEvent()['payload'];
         $order = $payload['order'];
 
+        $cartIdAbsent = empty($order[OrderInterface::QUOTE_ID]);
+        if ($cartIdAbsent) {
+            return false;
+        }
+
         // The `is_object_new` extension attribute is set by the plugin on all new orders.
         // If the attribute is missing this indicates that the order pre-dates the plugin
         //      and therefore no cart will exist in Solve.
@@ -56,8 +61,8 @@ GRAPHQL;
             return false;
         }
 
-        // The absence of an order's `remote_ip` field is inferred to mean that the order wasn't created by
-        //      a human and therefore there no associated cart would have been created.
+        // The absence of an order's `remote_ip` field is inferred to mean that the order was created by
+        //      an automated process rather than a customer and therefore no associated cart would have been created.
         $automatedOrder = empty($order[OrderInterface::REMOTE_IP]);
         if ($automatedOrder) {
             return false;

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/RegisterCustomer.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/RegisterCustomer.php
@@ -7,7 +7,7 @@ namespace SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesO
 use Magento\Sales\Api\Data\OrderInterface;
 use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbstract;
 
-class RegisterGuestCustomer extends MutationAbstract
+class RegisterCustomer extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
 mutation createOrUpdateProfile($input: ProfileInput!) {
@@ -17,26 +17,6 @@ mutation createOrUpdateProfile($input: ProfileInput!) {
     }
 }
 GRAPHQL;
-
-    /**
-     * Mutation is allowed
-     *
-     * @return bool
-     */
-    public function isAllowed(): bool
-    {
-        $payload = $this->getEvent()['payload'];
-        if (empty($payload['order'][OrderInterface::CUSTOMER_IS_GUEST])) {
-            return false;
-        }
-        if (empty($payload['order'][OrderInterface::EXTENSION_ATTRIBUTES_KEY]['is_object_new'])
-            && empty($payload['order'][OrderInterface::EXTENSION_ATTRIBUTES_KEY]['is_import_to_solve_data'])
-        ) {
-            return false;
-        }
-
-        return parent::isAllowed();
-    }
 
     /**
      * Get variables for GraphQL request

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -282,6 +282,10 @@ class PayloadConverter
             }
         }
 
+        if (!empty($order[OrderInterface::CUSTOMER_EMAIL])) {
+            $attributes['magento_customer_email'] = $order[OrderInterface::CUSTOMER_EMAIL];
+        }
+
         if (!empty($order[OrderInterface::QUOTE_ID])) {
             $attributes['magento_quote_id'] = $order[OrderInterface::QUOTE_ID];
         }

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -599,6 +599,8 @@ class PayloadConverter
     public function convertReturnData(array $order, array $area): array
     {
         $payment = $this->getOrderPaymentData($order);
+        
+        $orderId = $order[OrderInterface::INCREMENT_ID];
         $data = [
             // Use the order ID suffixed with `-return` as the return's ID as payments's
             //  entity ID field does not always exist.

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -290,6 +290,10 @@ class PayloadConverter
             $attributes['magento_quote_id'] = $order[OrderInterface::QUOTE_ID];
         }
 
+        if (!empty($order[OrderInterface::EXTENSION_ATTRIBUTES_KEY]['is_import_to_solve_data'])) {
+            $attributes['imported_at'] = $this->getFormattedDatetime();
+        }
+
         return $attributes;
     }
 

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -282,6 +282,10 @@ class PayloadConverter
             }
         }
 
+        if (!empty($order[OrderInterface::QUOTE_ID])) {
+            $attributes['magento_quote_id'] = $order[OrderInterface::QUOTE_ID];
+        }
+
         return $attributes;
     }
 
@@ -599,7 +603,7 @@ class PayloadConverter
     public function convertReturnData(array $order, array $area): array
     {
         $payment = $this->getOrderPaymentData($order);
-        
+
         $orderId = $order[OrderInterface::INCREMENT_ID];
         $data = [
             // Use the order ID suffixed with `-return` as the return's ID as payments's

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Run the following command Magento project directory (not the repository root) to
 - http://solvedata.local:8282 - PhpRedisAdmin
 - http://solvedata.local:5601 - Kibana
 
+### Running unit tests
+
+**Installing phpunit**
+We are using an older version of phpunit to avoid dependency conflicts with Magento's dependencies.
+```
+composer require --ignore-platform-reqs --dev phpunit/phpunit ^6
+```
+
+**Running tests**
+```
+./vendor/phpunit/phpunit/phpunit ./vendor/solvedata/plugins-magento2/tests/
+```
+
 ## Handle a new Magento event
 1. Add a new event to `etc/events.xml` and describe which observer class will be processed.
     ```

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Magento 2 Solve Data extension",
   "license": "Apache-2.0",
   "type": "magento2-module",
-  "version": "1.0.66",
+  "version": "1.0.67",
   "require": {
     "php": "~7.2",
     "magento/module-catalog": ">=103.0",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -29,6 +29,13 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+                <field id="enabled_convert_historical_carts" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable cart conversions for historical orders</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
                 <field id="debug" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Debug</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -6,6 +6,7 @@
                 <enabled>0</enabled>
                 <enabled_events>sales_order_save_after,sales_order_shipment_save_after,customer_register_success,customer_account_edited,customer_address_save_after,customer_login,customer_logout,checkout_cart_save_after,newsletter_subscriber_save_commit_after,order_cancel_after</enabled_events>
                 <enabled_anonymous_cart_events>0</enabled_anonymous_cart_events>
+                <enabled_convert_historical_carts>0</enabled_convert_historical_carts>
                 <debug>0</debug>
                 <cron_batch_size>100</cron_batch_size>
                 <transaction_batch_size>10</transaction_batch_size>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SolveData_Events" setup_version="1.0.66">
+    <module name="SolveData_Events" setup_version="1.0.67">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Checkout"/>

--- a/etc/solvedata_events.xml
+++ b/etc/solvedata_events.xml
@@ -23,7 +23,7 @@
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\NewsletterSubscriberSaveCommitAfter"/>
         </event>
         <event name="sales_order_save_after">
-            <mutation order="10" class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\RegisterGuestCustomer"/>
+            <mutation order="10" class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\RegisterCustomer"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdateOrder"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\ConvertCart"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdatePayment"/>

--- a/tests/mutations/ConvertCartTest.php
+++ b/tests/mutations/ConvertCartTest.php
@@ -23,10 +23,8 @@ class ConvertCartTest extends TestCase
 }
 PAYLOAD;
 
-        $anonymousCartsEnabled = false;
-
         $mutation = new ConvertCart(
-            $this->createConfig($anonymousCartsEnabled),
+            $this->createConfig(),
             $this->createPayloadConverter()
         );
         $mutation->setEvent(['payload' => $payload]);
@@ -50,11 +48,9 @@ PAYLOAD;
     "area": {}
 }
 PAYLOAD;
-
-        $anonymousCartsEnabled = false;
         
         $mutation = new ConvertCart(
-            $this->createConfig($anonymousCartsEnabled),
+            $this->createConfig(),
             $this->createPayloadConverter()
         );
         $mutation->setEvent(['payload' => $payload]);
@@ -131,16 +127,40 @@ PAYLOAD;
     "area": {}
 }
 PAYLOAD;
-
-        $anonymousCartsEnabled = false;
         
         $mutation = new ConvertCart(
-            $this->createConfig($anonymousCartsEnabled),
+            $this->createConfig(),
             $this->createPayloadConverter()
         );
         $mutation->setEvent(['payload' => $payload]);
 
         $this->assertFalse($mutation->isAllowed());
+    }
+
+    public function testIsAllowedIsTrueWhenHistoricalOrderIsImportedAndHistoricalCartConversionIsEnabled(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "quote_id": "95",
+        "remote_ip": "8.8.8.8",
+        "extension_attributes": {}
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $anonymousCartsEnabled = false;
+        $historicalCartConversion = true;
+        
+        $mutation = new ConvertCart(
+            $this->createConfig($anonymousCartsEnabled, $historicalCartConversion),
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertTrue($mutation->isAllowed());
     }
 
     public function testIsAllowedIsFalseWhenRemoteIpIsAbsent(): void
@@ -260,7 +280,7 @@ PAYLOAD;
         );
     }
 
-    private function createConfig($anonymousCartsEnabled = false): Config
+    private function createConfig($anonymousCartsEnabled = false, $convertHistoricCarts = false): Config
     {
         $config = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
@@ -268,6 +288,9 @@ PAYLOAD;
         
         $config->method('isAnonymousCartsEnabled')
                ->willReturn($anonymousCartsEnabled);
+        
+        $config->method('convertHistoricalCarts')
+               ->willReturn($convertHistoricCarts);
         
         return $config;
     }

--- a/tests/mutations/ConvertCartTest.php
+++ b/tests/mutations/ConvertCartTest.php
@@ -1,0 +1,277 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SolveData\Events\Model\Config;
+use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\ConvertCart;
+use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\PayloadConverter;
+
+class ConvertCartTest extends TestCase
+{
+    public function testIsAllowedIsTrueWhenIsGuestCustomerIsAbsent(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "quote_id": "95",
+        "remote_ip": "8.8.8.8",
+        "extension_attributes": {
+            "is_object_new": true
+        }
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $anonymousCartsEnabled = false;
+
+        $mutation = new ConvertCart(
+            $this->createConfig($anonymousCartsEnabled),
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertTrue($mutation->isAllowed());
+    }
+
+    public function testIsAllowedIsTrueWhenIsGuestCustomerIsPresentButFalse(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "quote_id": "95",
+        "remote_ip": "8.8.8.8",
+        "customer_is_guest": 0,
+        "extension_attributes": {
+            "is_object_new": true
+        }
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $anonymousCartsEnabled = false;
+        
+        $mutation = new ConvertCart(
+            $this->createConfig($anonymousCartsEnabled),
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertTrue($mutation->isAllowed());
+    }
+
+    public function testIsAllowedIsFalseWhenIsGuestCustomer(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "quote_id": "95",
+        "remote_ip": "8.8.8.8",
+        "customer_is_guest": 1,
+        "extension_attributes": {
+            "is_object_new": true
+        }
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $anonymousCartsEnabled = false;
+        
+        $mutation = new ConvertCart(
+            $this->createConfig($anonymousCartsEnabled),
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertFalse($mutation->isAllowed());
+    }
+
+    public function testIsAllowedIsFalseWhenHistoricalOrderIsImported(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "quote_id": "95",
+        "remote_ip": "8.8.8.8",
+        "extension_attributes": {}
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $anonymousCartsEnabled = false;
+        
+        $mutation = new ConvertCart(
+            $this->createConfig($anonymousCartsEnabled),
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertFalse($mutation->isAllowed());
+    }
+
+    public function testIsAllowedIsFalseWhenRemoteIpIsAbsent(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "quote_id": "95",
+        "extension_attributes": {
+            "is_object_new": true
+        }
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $anonymousCartsEnabled = false;
+        
+        $mutation = new ConvertCart(
+            $this->createConfig($anonymousCartsEnabled),
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertFalse($mutation->isAllowed());
+    }
+
+    public function testIsAllowedIsFalseWhenIsObjectNewExtensionAttributeIsMissing(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "quote_id": "95",
+        "remote_ip": "8.8.8.8",
+        "extension_attributes": {}
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $anonymousCartsEnabled = true;
+        
+        $mutation = new ConvertCart(
+            $this->createConfig($anonymousCartsEnabled),
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertFalse($mutation->isAllowed());
+    }
+
+    public function testIsAllowedIsTrueWhenGuestCartsAreEnabled(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "quote_id": "95",
+        "remote_ip": "8.8.8.8",
+        "customer_is_guest": 1,
+        "extension_attributes": {
+            "is_object_new": true
+        }
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $anonymousCartsEnabled = false;
+        
+        $mutation = new ConvertCart(
+            $this->createConfig($anonymousCartsEnabled),
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertFalse($mutation->isAllowed());
+    }
+
+    public function testMuationVariables(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "quote_id": "95",
+        "remote_ip": "8.8.8.8",
+        "extension_attributes": {
+            "is_object_new": true
+        }
+    },
+    "area": {
+        "website (Magento\\Store\\Model\\Website\\Interceptor)": {
+            "code": "unit_test_store"
+        }
+    }
+}
+PAYLOAD;
+
+        $mutation = new ConvertCart(
+            $this->createConfig(),
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $variables = $mutation->getVariables();
+
+        $this->assertArraySubset(
+            [
+                'id'       => '95',
+                'orderId'  => '1001',
+                'provider' => 'unit_test_store'
+            ],
+            $variables
+        );
+    }
+
+    private function createConfig($anonymousCartsEnabled = false): Config
+    {
+        $config = $this->getMockBuilder(Config::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $config->method('isAnonymousCartsEnabled')
+               ->willReturn($anonymousCartsEnabled);
+        
+        return $config;
+    }
+
+    private function createPayloadConverter(): PayloadConverter
+    {
+        $countryFactory = $this->getMockBuilder('Magento\Directory\Model\CountryFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $profileHelper = $this->getMockBuilder('SolveData\Events\Helper\Profile')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $regionFactory = $this->getMockBuilder('Magento\Directory\Model\RegionFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $storeManager = $this->getMockBuilder('Magento\Store\Model\StoreManagerInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $logger = $this->getMockBuilder('SolveData\Events\Model\Logger')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        return new PayloadConverter(
+            $countryFactory,
+            $profileHelper,
+            $regionFactory,
+            $storeManager,
+            $logger
+        );
+    }
+}

--- a/tests/mutations/ConvertCartTest.php
+++ b/tests/mutations/ConvertCartTest.php
@@ -62,6 +62,34 @@ PAYLOAD;
         $this->assertTrue($mutation->isAllowed());
     }
 
+
+    public function testIsAllowedIsFalseWhenQouteIdIsAbsent(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "remote_ip": "8.8.8.8",
+        "customer_is_guest": 0,
+        "extension_attributes": {
+            "is_object_new": true
+        }
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $anonymousCartsEnabled = false;
+        
+        $mutation = new ConvertCart(
+            $this->createConfig($anonymousCartsEnabled),
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertFalse($mutation->isAllowed());
+    }
+
     public function testIsAllowedIsFalseWhenIsGuestCustomer(): void
     {
         $payload = <<<'PAYLOAD'

--- a/tests/mutations/CreateOrUpdateOrderTest.php
+++ b/tests/mutations/CreateOrUpdateOrderTest.php
@@ -67,7 +67,8 @@ PAYLOAD;
 
         $this->assertArraySubset(
             [
-                'magento_quote_id' => 'q-123'
+                'magento_quote_id'       => 'q-123',
+                'magento_customer_email' => 'jane@example.com'
             ],
             json_decode($variables['input']['attributes'], true)
         );

--- a/tests/mutations/CreateOrUpdateOrderTest.php
+++ b/tests/mutations/CreateOrUpdateOrderTest.php
@@ -74,6 +74,43 @@ PAYLOAD;
         );
     }
 
+    public function testImportedOrderAttribute(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "quote_id": "q-123",
+        "customer_email": "jane@example.com",
+        "order_currency_code": "USD",
+        "store_id": 1,
+        "shipping_amount": "1.0000",
+        "tax_amount": "0.2000",
+        "addresses": [],
+        "extension_attributes": {
+            "is_import_to_solve_data": true
+        }
+    },
+    "orderAllVisibleItems": [],
+    "area": {
+        "website (Magento\\Store\\Model\\Website\\Interceptor)": {
+            "code": "unit_test_store"
+        }
+    }
+}
+PAYLOAD;
+
+        $mutation = new CreateOrUpdateOrder(
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $variables = $mutation->getVariables();
+
+        $orderAttributes = json_decode($variables['input']['attributes'], true);
+        $this->assertArrayHasKey('imported_at', $orderAttributes);
+    }
+
     private function createPayloadConverter(): PayloadConverter
     {
         $countryFactory = $this->getMockBuilder('Magento\Directory\Model\CountryFactory')

--- a/tests/mutations/CreateOrUpdateOrderTest.php
+++ b/tests/mutations/CreateOrUpdateOrderTest.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdateOrder;
+use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\PayloadConverter;
+
+class CreateOrUpdateOrderTest extends TestCase
+{
+    public function testIsAlwaysAllowed(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {},
+    "area": {}
+}
+PAYLOAD;
+
+        $mutation = new CreateOrUpdateOrder(
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertTrue($mutation->isAllowed());
+    }
+
+    public function testMuationInput(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "quote_id": "q-123",
+        "customer_email": "jane@example.com",
+        "order_currency_code": "USD",
+        "store_id": 1,
+        "shipping_amount": "1.0000",
+        "tax_amount": "0.2000",
+        "addresses": []
+    },
+    "orderAllVisibleItems": [],
+    "area": {
+        "website (Magento\\Store\\Model\\Website\\Interceptor)": {
+            "code": "unit_test_store"
+        }
+    }
+}
+PAYLOAD;
+
+        $mutation = new CreateOrUpdateOrder(
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $variables = $mutation->getVariables();
+
+        $this->assertArraySubset(
+            [
+                'id'              => '1001',
+                'provider'        => 'unit_test_store',
+                'status'          => 'CREATED',
+                'currency'        => 'USD',
+                'items'           => [],
+                'storeIdentifier' => '1',
+            ],
+            $variables['input']
+        );
+
+        $this->assertArraySubset(
+            [
+                'magento_quote_id' => 'q-123'
+            ],
+            json_decode($variables['input']['attributes'], true)
+        );
+    }
+
+    private function createPayloadConverter(): PayloadConverter
+    {
+        $countryFactory = $this->getMockBuilder('Magento\Directory\Model\CountryFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $profileHelper = $this->getMockBuilder('SolveData\Events\Helper\Profile')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $regionFactory = $this->getMockBuilder('Magento\Directory\Model\RegionFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $storeManager = $this->getMockBuilder('Magento\Store\Model\StoreManagerInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $logger = $this->getMockBuilder('SolveData\Events\Model\Logger')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        return new PayloadConverter(
+            $countryFactory,
+            $profileHelper,
+            $regionFactory,
+            $storeManager,
+            $logger
+        );
+    }
+}

--- a/tests/mutations/CreateOrUpdatePaymentTest.php
+++ b/tests/mutations/CreateOrUpdatePaymentTest.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\CreateOrUpdatePayment;
+use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\PayloadConverter;
+
+class CreateOrUpdatePaymentTest extends TestCase
+{
+    public function testNotAllowedIfPaymentDataDoesIsNotPresent(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {},
+    "area": {}
+}
+PAYLOAD;
+
+        $mutation = new CreateOrUpdatePayment(
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertFalse($mutation->isAllowed());
+    }
+
+    public function testNotAllowedIfAmountPaidIsAbsent(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "payment (Magento\\Sales\\Model\\Order\\Payment\\Interceptor)": {}
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $mutation = new CreateOrUpdatePayment(
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertFalse($mutation->isAllowed());
+    }
+
+    public function testNotAllowedIfAmountPaidIsZero(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "payment (Magento\\Sales\\Model\\Order\\Payment\\Interceptor)": {
+            "amount_paid": "0.0000"
+        }
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $mutation = new CreateOrUpdatePayment(
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertFalse($mutation->isAllowed());
+    }
+
+    public function testAllowedIfAmountPaidIsNonZero(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "payment (Magento\\Sales\\Model\\Order\\Payment\\Interceptor)": {
+            "amount_paid": "1.0000"
+        }
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $mutation = new CreateOrUpdatePayment(
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertTrue($mutation->isAllowed());
+    }
+
+    public function testMuationInputCorrectlyGeneratesPaymentId(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "increment_id": "1001",
+        "payment (Magento\\Sales\\Model\\Order\\Payment\\Interceptor)": {
+            "amount_paid": "1.0000"
+        }
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $mutation = new CreateOrUpdatePayment(
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $variables = $mutation->getVariables();
+        $this->assertArrayHasKey('id', $variables['input']);
+        $this->assertEquals(
+            $variables['input']['id'],
+            '1001-payment'
+        );
+    }
+
+    private function createPayloadConverter(): PayloadConverter
+    {
+        $countryFactory = $this->getMockBuilder('Magento\Directory\Model\CountryFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $profileHelper = $this->getMockBuilder('SolveData\Events\Helper\Profile')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $regionFactory = $this->getMockBuilder('Magento\Directory\Model\RegionFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $storeManager = $this->getMockBuilder('Magento\Store\Model\StoreManagerInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $logger = $this->getMockBuilder('SolveData\Events\Model\Logger')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        return new PayloadConverter(
+            $countryFactory,
+            $profileHelper,
+            $regionFactory,
+            $storeManager,
+            $logger
+        );
+    }
+}

--- a/tests/mutations/RegisterCustomerTest.php
+++ b/tests/mutations/RegisterCustomerTest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesOrderSaveAfter\RegisterCustomer;
+use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\PayloadConverter;
+
+class RegisterCustomerTest extends TestCase
+{
+    public function testEveryOrderShouldRegisterACustomer(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {},
+    "area": {}
+}
+PAYLOAD;
+
+        $mutation = new RegisterCustomer(
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $this->assertTrue($mutation->isAllowed());
+    }
+
+    public function testMuationInputIncludeEmail(): void
+    {
+        $payload = <<<'PAYLOAD'
+{
+    "order": {
+        "customer_email": "jane@example.com"
+    },
+    "area": {}
+}
+PAYLOAD;
+
+        $mutation = new RegisterCustomer(
+            $this->createPayloadConverter()
+        );
+        $mutation->setEvent(['payload' => $payload]);
+
+        $variables = $mutation->getVariables();
+        $this->assertArrayHasKey('email', $variables['input']);
+        $this->assertEquals(
+            $variables['input']['email'],
+            'jane@example.com'
+        );
+    }
+
+    private function createPayloadConverter(): PayloadConverter
+    {
+        $countryFactory = $this->getMockBuilder('Magento\Directory\Model\CountryFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $profileHelper = $this->getMockBuilder('SolveData\Events\Helper\Profile')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $regionFactory = $this->getMockBuilder('Magento\Directory\Model\RegionFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $storeManager = $this->getMockBuilder('Magento\Store\Model\StoreManagerInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $logger = $this->getMockBuilder('SolveData\Events\Model\Logger')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        return new PayloadConverter(
+            $countryFactory,
+            $profileHelper,
+            $regionFactory,
+            $storeManager,
+            $logger
+        );
+    }
+}


### PR DESCRIPTION
This PR changes the series of mutations made when processing order events so they always send through a `create_or_update_profile` mutation even when when the order wasn't placed by a guest customer.

This is because the profile may not exist when we are importing historic orders. Since order events are relatively rare when compared with cart events we should not mind doing the extra `create_or_update_profile` mutation for every order.

In addition this PR also:

- Adds a configuration option to attempt cart conversion for historical orders. This will allow us to convert carts for orders where their `convert_cart` mutations previously failed.
- Introduces unit tests. These will be fleshed out in future PRs.
- Fixes a bug in the return mutation due to a missing variable (uncovered by unit tests)

**Considerations**
This `create_or_update_profile`'s variables come from the order event and therefore may not be as trustworthy as the information that comes directly from other events. Therefore I think it might be best to keep this `create_or_update_profile` mutation stripped down in terms of the fields it sets so we aren't upserting profile information from the register/login events which are likely to be more reliable source of customer information.