### PR TITLE
Drop unique index on profile_id

### DIFF
--- a/Setup/Patch/Schema/DropSidUniqueIndexInSolvedataProfileTable.php
+++ b/Setup/Patch/Schema/DropSidUniqueIndexInSolvedataProfileTable.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SolveData\Events\Setup\Patch\Schema;
+
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Ddl\Table;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\SchemaPatchInterface;
+use SolveData\Events\Model\ResourceModel\Profile as ResourceModel;
+
+class DropSidUniqueIndexInSolvedataProfileTable implements SchemaPatchInterface
+{
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    protected $moduleDataSetup;
+
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply()
+    {
+        $connection = $this->moduleDataSetup->getConnection();
+        $connection->startSetup();
+        $tableName = $connection->getTableName(ResourceModel::TABLE_NAME);
+
+        $connection->dropIndex(
+            $tableName,
+            $connection->getIndexName(
+                ResourceModel::TABLE_NAME,
+                ['sid'],
+                AdapterInterface::INDEX_TYPE_UNIQUE
+            )
+        );
+
+        $connection->endSetup();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function revert()
+    {
+        $connection = $this->moduleDataSetup->getConnection();
+        $connection->startSetup();
+        $tableName = $connection->getTableName(ResourceModel::TABLE_NAME);
+
+        $connection->addIndex(
+            $connection->getIndexName(
+                ResourceModel::TABLE_NAME,
+                ['sid'],
+                AdapterInterface::INDEX_TYPE_UNIQUE
+            ),
+            ['sid'],
+            ['type' => AdapterInterface::INDEX_TYPE_UNIQUE]
+        );
+
+        $connection->endSetup();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDependencies()
+    {
+        return [
+            CreateSolvedataProfileTable::class,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
This migration will be executed when the plugin is updated to the latest version (i.e. when `magento setup:upgrade` is ran). In the worst case if the migration is not ran in a customer's environment when the plugin is updated, the behaviour will be the same as it is currently.

The plugin does not lookup emails by profile ID and therefore this index is solely used as a data constraint and dropping the index shouldn't have any negative performance implications.

**Before**
```
mysql> SHOW INDEX FROM solvedata.solvedata_profile;
+-------------------+------------+-------------------------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table             | Non_unique | Key_name                                              | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+-------------------+------------+-------------------------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| solvedata_profile |          0 | PRIMARY                                               |            1 | id          | A         |          14 |     NULL | NULL   |      | BTREE      |         |               |
| solvedata_profile |          0 | SOLVEDATA_PROFILE_SID                                 |            1 | sid         | A         |          14 |     NULL | NULL   |      | BTREE      |         |               |
| solvedata_profile |          0 | SOLVEDATA_PROFILE_EMAIL_WEBSITE_ID                    |            1 | email       | A         |          14 |     NULL | NULL   |      | BTREE      |         |               |
| solvedata_profile |          0 | SOLVEDATA_PROFILE_EMAIL_WEBSITE_ID                    |            2 | website_id  | A         |          14 |     NULL | NULL   |      | BTREE      |         |               |
| solvedata_profile |          1 | SOLVEDATA_PROFILE_WEBSITE_ID_STORE_WEBSITE_WEBSITE_ID |            1 | website_id  | A         |           2 |     NULL | NULL   |      | BTREE      |         |               |
+-------------------+------------+-------------------------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
```

**After**
```
mysql> SHOW INDEX FROM solvedata.solvedata_profile;
+-------------------+------------+-------------------------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table             | Non_unique | Key_name                                              | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+-------------------+------------+-------------------------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| solvedata_profile |          0 | PRIMARY                                               |            1 | id          | A         |          14 |     NULL | NULL   |      | BTREE      |         |               |
| solvedata_profile |          0 | SOLVEDATA_PROFILE_EMAIL_WEBSITE_ID                    |            1 | email       | A         |          14 |     NULL | NULL   |      | BTREE      |         |               |
| solvedata_profile |          0 | SOLVEDATA_PROFILE_EMAIL_WEBSITE_ID                    |            2 | website_id  | A         |          14 |     NULL | NULL   |      | BTREE      |         |               |
| solvedata_profile |          1 | SOLVEDATA_PROFILE_WEBSITE_ID_STORE_WEBSITE_WEBSITE_ID |            1 | website_id  | A         |           2 |     NULL | NULL   |      | BTREE      |         |               |
+-------------------+------------+-------------------------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
```